### PR TITLE
Improve development onboarding

### DIFF
--- a/.docker.env
+++ b/.docker.env
@@ -1,0 +1,12 @@
+DATABASE_URL=postgresql://root:root@postgres/cubedesk
+REDIS_URL=redis://redis:6379
+
+JWT_SECRET=abcd
+NODE_ENV=development
+ENV=development
+PORT=3000
+HTTPS=false
+BASE_URI=http://localhost:3000
+LOG_LEVEL=debug
+RESOURCES_BASE_URI=/public
+DIST_BASE_URI=/dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,65 @@
+services:
+
+  app-builder:
+    image: node:16
+    working_dir: /app
+    volumes:
+      - ./:/app
+      - npm_cache:/root/.npm
+      - yarn_cache:/usr/local/share/.cache
+    command: yarn build
+    depends_on:
+      - redis
+      - postgres
+
+  app-graphql:
+    extends:
+      service: app-builder
+    command: npx graphql-codegen --watch
+
+  app-server:
+    ports:
+      - 3000:3000
+    extends:
+      service: app-builder
+    command: yarn server
+
+  install:
+    extends:
+      service: app-builder
+    profiles:
+      - install
+    entrypoint:
+      - /bin/sh
+      - -c
+    command:
+      - |
+        set -e
+        yarn
+        npx prisma format
+        npx prisma generate
+        npx prisma migrate dev
+
+  redis:
+    image: redis:7
+    ports:
+      - 6379:6379
+    volumes:
+      - redis_data:/data
+
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_DB: cubedesk
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: root
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:
+  redis_data:
+  npm_cache:
+  yarn_cache:

--- a/server/services/discord.ts
+++ b/server/services/discord.ts
@@ -13,6 +13,10 @@ type DiscordRole = 'Pro' | 'Admin';
 
 export default class Discord {
 	static async init() {
+		if (!process.env.DISCORD_SERVER_ID) {
+			logger.warn('Discord client is not initialized: DISCORD_SERVER_ID is not set');
+			return;
+		}
 		client = new Client({
 			intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MEMBERS],
 		});

--- a/server/services/storage.ts
+++ b/server/services/storage.ts
@@ -1,12 +1,18 @@
 import {S3Client} from '@aws-sdk/client-s3-node/S3Client';
 import {PutObjectCommand, PutObjectInput} from '@aws-sdk/client-s3-node/commands/PutObjectCommand';
 import {DeleteObjectCommand} from '@aws-sdk/client-s3-node/commands/DeleteObjectCommand';
+import {logger} from './logger';
 
 const BUCKET_NAME = 'cubedesk';
 
-const s3 = new S3Client({region: 'us-west-2'});
+const isDev = process.env.ENV === 'development';
+const s3 = isDev ? undefined : new S3Client({region: 'us-west-2'});
 
 export async function uploadObject(fileBuffer: Buffer, path: string, options: Partial<PutObjectInput> = {}) {
+	if (isDev) {
+		logger.warn('S3 is not available in development environment - Upload Object command is ignored');
+		return Promise.resolve();
+	}
 	const params: PutObjectInput = {
 		Bucket: BUCKET_NAME,
 		Key: path,
@@ -19,6 +25,10 @@ export async function uploadObject(fileBuffer: Buffer, path: string, options: Pa
 }
 
 export async function deleteObject(path: string) {
+	if (isDev) {
+		logger.warn('S3 is not available in development environment - Delete Object command is ignored');
+		return Promise.resolve();
+	}
 	const params = {
 		Bucket: BUCKET_NAME,
 		Key: path,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,8 +42,9 @@ module.exports = [
 		plugins,
 		watch: !deploying,
 		watchOptions: {
-			aggregateTimeout: 200,
-			poll: 200,
+			aggregateTimeout: 2000,
+			poll: 5000,
+			ignored: ['**/node_modules', '**/.git'],
 		},
 		resolve: {
 			extensions: ['.ts', '.tsx', '.jsx', '.js', '.json'],


### PR DESCRIPTION
This PR is intended to make developer onboarding process easier.
Things that have been done:

1. Discord and storage services does not take into account development environment. This causes server crash on startup and inability to run development environment.

2. Parameters used for webpack watch mode causes excessive CPU and I/O overhead for nothing. My MacBook turn on all the helicopters and sounds like hurricane. Omitting why polling is ever used here, let's say for compatibility for environments where fsevents are not supported, like mounted inside docker container volumes on Windows hosts. Polling filesystem by 200ms is madness, especially for fairly large codebase, given that in the typical development process 5 seconds polling is usually more than enough to detect and compile changes in background. Moreover each code change causes ts-node-dev respawn the server, so it takes much longer time to apply changes and such frequent polling is not required.

3. Proposed onboarding process is highly invasive, because requires to install specific versions of development tools and supporting components right on the development host. Regardless of it may have conflicts with other projects developer in use, there is no any isolation and repeatability of the environment. That's why Docker was invented, I suppose every proficient developer use it. Personally I'm using Docker Desktop on macOS, but there are also podman and podman-compose exists.

I've added simple Docker Compose file, that can be used by developer to spin up required development environment with a couple of docker compose commands.

1. Copy environment file eligible for Docker:
```
$ cp .docker.env .env
```

2. Pull all required Docker images from registry:
```
$ docker compose pull
```

3. Run container performing module installation / database update procedure:
```
$ docker compose run --rm install
```

4. Spin up development environment:
```
$ docker compose up -d
```

5. View service logs:
```
$ docker compose logs -f
```

6. Stop development environment:
```
$ docker compose down
```

Further to start / stop development environment just issue `docker compose up -d` and `docker compose down` commands. If you want to clear all docker volumes with yarn/npm caches and database data run `docker compose down -v`. This will remove created docker volumes including postgress database data. Next time to spin up fresh environment run database update process once again `docker compose run --rm install`.


