### PR TITLE
Support for GAN Smart Timer via its bluetooth protocol

### DIFF
--- a/client/components/settings/timer/TimerSettings.tsx
+++ b/client/components/settings/timer/TimerSettings.tsx
@@ -16,6 +16,7 @@ export const TIMER_INPUT_TYPE_NAMES = {
 	keyboard: 'Keyboard',
 	stackmat: 'StackMat',
 	smart: 'Smart Cube',
+	gantimer: 'GAN Smart Timer',
 };
 
 export default function TimerSettings() {
@@ -88,7 +89,7 @@ export default function TimerSettings() {
 				<Dropdown
 					icon={null}
 					text={getTimerTypeName(timerType)}
-					options={['keyboard', 'stackmat', 'smart'].map((c) => ({
+					options={['keyboard', 'stackmat', 'smart', 'gantimer'].map((c) => ({
 						text: getTimerTypeName(c),
 						onClick: () => updateSetting('timer_type', c),
 					}))}

--- a/client/components/timer/Timer.scss
+++ b/client/components/timer/Timer.scss
@@ -193,7 +193,7 @@
 			pointer-events: none;
 			opacity: 0.3;
 		}
-
+		#{$self}-bottom-info,
 		#{$self}-scramble,
 		#{$self}-footer {
 			pointer-events: none;

--- a/client/components/timer/Timer.tsx
+++ b/client/components/timer/Timer.tsx
@@ -12,6 +12,7 @@ import block from '../../styles/bem';
 import {useGeneral} from '../../util/hooks/useGeneral';
 import {useMe} from '../../util/hooks/useMe';
 import {initTimer} from './helpers/init';
+import {stopAllTimers} from './helpers/timers';
 import {useSettings} from '../../util/hooks/useSettings';
 import {listenForPbEvents} from './helpers/pb';
 import {useWindowListener} from '../../util/hooks/useListener';
@@ -72,10 +73,10 @@ export default function Timer(props: TimerProps) {
 
 		// Go back to the default settings when user leaves page
 		return () => {
+			stopAllTimers();
 			dispatch({
 				type: 'RESET_TIMER_PARAMS',
 			});
-
 			toggleHtmlOverflow('unset');
 		};
 	}, []);

--- a/client/components/timer/header_control/HeaderControl.tsx
+++ b/client/components/timer/header_control/HeaderControl.tsx
@@ -102,6 +102,10 @@ export default function HeaderControl() {
 					disabled: cubeType !== '333',
 					onClick: () => selectTimerType('smart'),
 				},
+				{
+					text: 'GAN Smart Timer',
+					onClick: () => selectTimerType('gantimer'),
+				},
 			]}
 		/>
 	);

--- a/client/components/timer/helpers/timers.ts
+++ b/client/components/timer/helpers/timers.ts
@@ -35,6 +35,10 @@ export function stopTimer(name) {
 	timers[name] = null;
 }
 
+export function stopAllTimers() {
+	Object.keys(timers).forEach(name => stopTimer(name));
+}
+
 export function clearInspectionTimers(clearModifications: boolean, run: boolean) {
 	stopTimer(INSPECTION_TIMEOUT);
 	stopTimer(INSPECTION_INTERVAL);

--- a/client/components/timer/time_display/TimeDisplay.tsx
+++ b/client/components/timer/time_display/TimeDisplay.tsx
@@ -11,8 +11,10 @@ import block from '../../../styles/bem';
 import {useSettings} from '../../../util/hooks/useSettings';
 import StartInstructions from './start_instructions/StartInstructions';
 import StackMat from './stackmat/StackMat';
+import GanTimer from './gantimer/GanTimer';
 
 const b = block('time-display');
+const bi = block('timer-bottom-info');
 
 export default function TimeDisplay() {
 	const context = useContext(TimerContext);
@@ -42,6 +44,7 @@ export default function TimeDisplay() {
 	const timerFontFamily = useSettings('timer_font_family');
 	const timerType = useSettings('timer_type');
 	const stackMatOn = timerType === 'stackmat';
+	const ganTimerOn = timerType === 'gantimer';
 	const zeroOutTimeAfterSolve = useSettings('zero_out_time_after_solve');
 
 	const mobileMode = useGeneral('mobile_mode');
@@ -55,6 +58,8 @@ export default function TimeDisplay() {
 			stopInterval();
 		} else if (!timerCounter.current && timeStartedAt) {
 			startInterval();
+		} if (!solving && finalTime < 0) {
+			setTime(0);
 		}
 	}, [solving, finalTime, timeStartedAt]);
 
@@ -122,6 +127,8 @@ export default function TimeDisplay() {
 
 	if (stackMatOn) {
 		bottomInfo = <StackMat />;
+	} else if (ganTimerOn) {
+		bottomInfo = <GanTimer />;
 	} else if (smartCubeSelected(context)) {
 		if (preflightChecks(smartTurns, scramble)) {
 			bottomInfo = (
@@ -151,7 +158,7 @@ export default function TimeDisplay() {
 			>
 				{timeStr}
 			</h1>
-			{bottomInfo}
+			<div className={bi()}>{bottomInfo}</div>
 			{subTimerActions}
 		</>
 	);

--- a/client/components/timer/time_display/gantimer/GanTimer.tsx
+++ b/client/components/timer/time_display/gantimer/GanTimer.tsx
@@ -1,0 +1,87 @@
+
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import { ITimerContext, TimerContext } from '../../Timer';
+import Emblem from '../../../common/emblem/Emblem';
+import { startTimer, endTimer, startInspection, cancelInspection } from '../../helpers/events';
+import { setTimerParams } from '../../helpers/params';
+import { useSettings } from '../../../../util/hooks/useSettings';
+
+import { SubscriptionLike } from 'rxjs';
+import { GanTimerConnection, GanTimerEvent, GanTimerState, connectGanTimer } from 'gan-web-bluetooth';
+
+// Since this component is singleton and should never have multiple instances,
+// also will never be used in different contexts, we won't pollute context
+// with connection status and event subscription. Just use module-scoped variables.
+var conn: GanTimerConnection | null = null;
+var subs: SubscriptionLike | null = null;
+
+export default function GanTimer() {
+
+	const inspectionEnabled = useSettings('inspection');
+	const [connected, setConnected] = useState(false);
+
+	const context = useContext(TimerContext);
+	const contextRef = useRef<ITimerContext>(context);
+	useEffect(() => {
+		contextRef.current = context;
+	}, [context]);
+
+	// Subscribe/unsubscribe to GAN Smart Timer events when component being mounted/unmounted
+	useEffect(() => {
+		subs = conn?.events$.subscribe(handleTimerEvent);
+		setConnected(!!conn);
+		return () => subs?.unsubscribe();
+	}, []);
+
+	function handleTimerEvent(event: GanTimerEvent) {
+		switch (event.state) {
+			case GanTimerState.HANDS_ON:
+				setTimerParams({ canStart: false, spaceTimerStarted: 1 });
+				break;
+			case GanTimerState.HANDS_OFF:
+				setTimerParams({ canStart: false, spaceTimerStarted: 0 });
+				break;
+			case GanTimerState.GET_SET:
+				setTimerParams({ canStart: true, spaceTimerStarted: 0 });
+				break;
+			case GanTimerState.RUNNING:
+				setTimerParams({ canStart: false, spaceTimerStarted: 0 });
+				startTimer();
+				break;
+			case GanTimerState.STOPPED:
+				endTimer(contextRef.current, event.recordedTime.asTimestamp);
+				break;
+			case GanTimerState.IDLE:
+				if (!inspectionEnabled || contextRef.current.inInspection || contextRef.current.finalTime > 0) {
+					cancelInspection();
+					setTimerParams({ spaceTimerStarted: 0, canStart: false, finalTime: -1 });
+				} else {
+					startInspection();
+				}
+				break;
+			case GanTimerState.DISCONNECT:
+				setConnected(false);
+				break;
+		}
+	}
+
+	async function handleConnectButton() {
+		if (conn) {
+			conn.disconnect();
+			conn = null;
+			setConnected(false);
+		} else {
+			conn = await connectGanTimer();
+			conn.events$.subscribe(evt => evt.state == GanTimerState.DISCONNECT && (conn = null));
+			subs = conn.events$.subscribe(handleTimerEvent);
+			setConnected(true);
+		}
+	}
+
+	return (
+		<div onClick={handleConnectButton} style={{ userSelect: 'none', cursor: 'pointer' }}>
+			<Emblem icon='ph-bluetooth' text={connected ? 'Connected' : 'Connect to Timer'} small red={!connected} green={connected} />
+		</div>
+	);
+
+}

--- a/client/db/settings/query.ts
+++ b/client/db/settings/query.ts
@@ -29,7 +29,7 @@ export interface AllSettings {
 	custom_cube_types: CustomCubeType[];
 
 	// Local
-	timer_type: 'keyboard' | 'smart' | 'stackmat';
+	timer_type: 'keyboard' | 'smart' | 'stackmat' | 'gantimer';
 	timer_layout: TimerLayoutPosition;
 	timer_module_count: number;
 	stackmat_id: string;

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
 		"express": "^4.16.3",
 		"file-loader": "4.1.0",
 		"flat": "^5.0.2",
+		"gan-web-bluetooth": "^1.0.3",
 		"graphql": "15.3.0",
 		"graphql-scalars": "^1.9.0",
 		"graphql-upload": "^12.0.0",


### PR DESCRIPTION
This PR adds support for GAN Smart Timer using Web Bluetooth API and timer's bluetooth protocol.

Made using my [gan-web-bluetooth](https://github.com/afedotov/gan-web-bluetooth) library designed for interaction with GAN Smart Timer.

I've not included updated `yarn.lock` file, suppose you make `yarn install && yarn upgrade` by yourself upon release process.

Since GAN Smart Timer allows you to get rid of keyboard usage during solving (inspection timer can be started/canceled just by pressing timer's big reset button) this involves little refactoring. Inspection start/stop procedure has been moved from `KeyWatcher` component.