### PR TITLE
Fix input audio device picker for StackMat

### DIFF
--- a/client/components/settings/stackmat_picker/StackMatPicker.tsx
+++ b/client/components/settings/stackmat_picker/StackMatPicker.tsx
@@ -32,7 +32,7 @@ export default function StackMatPicker(props: IModalProps) {
 				const storedIds = new Set();
 
 				for (const device of devices) {
-					if (device.kind !== 'audiooutput') {
+					if (device.kind !== 'audioinput') {
 						continue;
 					}
 


### PR DESCRIPTION
Fixes #117 and #125
Audio device for StackMat is wrongly picked as output, not input device.

This may not be an issue for environments where input and output audio devices has same `deviceId`, for example on macOS default input/output devices has same `deviceId == 'default'`. But if input and output `deviceId` differs this my be an issue preventing selecting proper device. Besides that this confuses user.

