### PR TITLE
Check for Web Bluetooth API availability

### DIFF
--- a/client/components/timer/common/BluetoothErrorMessage.tsx
+++ b/client/components/timer/common/BluetoothErrorMessage.tsx
@@ -1,0 +1,30 @@
+
+import React from 'react';
+import ModalHeader from '../../common/modal/modal_header/ModalHeader';
+
+export default function BluetoothErrorMessage() {
+
+    let title = <span style={{ color: 'rgb(var(--error-color))' }}>Bluetooth is not available!</span>;
+    let description = <span style={{ color: 'rgb(var(--warning-color))' }}>Check if Bluetooth is enabled on your system.</span>;
+
+    return (
+        <>
+            <ModalHeader title={title} description={description} />
+            <p>
+                Your browser may not support Web Bluetooth API.
+                Consider using compatible browser, the best choice is:
+                <ul style={{ listStyle: 'disc', margin: '1em', paddingLeft: '1em' }}>
+                    <li>Chrome on macOS, Linux, Android or Windows</li>
+                    <li>Bluefy on iOS</li>
+                </ul>
+                Also you can check &nbsp;
+                <a style={{ textDecoration: 'underline' }} target='_blank'
+                    href='https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md'>
+                    Web Bluetooth Community Group implementation status
+                </a>
+                &nbsp; for complete list of different browsers and supported Web Bluetooth API features.
+            </p>
+        </>
+    );
+
+}

--- a/client/components/timer/smart_cube/SmartCube.tsx
+++ b/client/components/timer/smart_cube/SmartCube.tsx
@@ -17,6 +17,7 @@ import Dropdown from '../../common/inputs/dropdown/Dropdown';
 import Button from '../../common/button/Button';
 import {toastError} from '../../../util/toast';
 import {endTimer, startTimer} from '../helpers/events';
+import BluetoothErrorMessage from '../common/BluetoothErrorMessage';
 
 const b = block('smart-cube');
 
@@ -224,11 +225,16 @@ export default function SmartCube() {
 		turnIndex.current += 1;
 	}
 
-	function connectBluetooth() {
+	async function connectBluetooth() {
 		try {
-			connect.current.connect();
+			let bluetoothAvailable = !!navigator.bluetooth && await navigator.bluetooth.getAvailability();
+			if (bluetoothAvailable) {
+				connect.current.connect();
+			} else {
+				dispatch(openModal(<BluetoothErrorMessage />));
+			}
 		} catch (e) {
-			toastError(e);
+			toastError('Web Bluetooth API error' + e ? `: ${e}` : '');
 			// chrome://flags/#enable-experimental-web-platform-features
 		}
 	}


### PR DESCRIPTION
Made bluetooth connection procedure little more user-friendly. Check if browser supports Web Bluetooth API and bluetooth is available, unless display modal dialog with error message and instructions.