### PR TITLE
Fix compose - run graphql-codegen once before first esbuild run

### DIFF
--- a/client/components/timer/smart_cube/SmartCube.tsx
+++ b/client/components/timer/smart_cube/SmartCube.tsx
@@ -234,7 +234,7 @@ export default function SmartCube() {
 				dispatch(openModal(<BluetoothErrorMessage />));
 			}
 		} catch (e) {
-			toastError('Web Bluetooth API error' + e ? `: ${e}` : '');
+			toastError('Web Bluetooth API error' + (e ? `: ${e}` : ''));
 			// chrome://flags/#enable-experimental-web-platform-features
 		}
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
         npx prisma format
         npx prisma generate
         npx prisma migrate dev
+        npx graphql-codegen
 
   redis:
     image: redis:7


### PR DESCRIPTION
Run `graphql-codegen` once during installation phase, unless `esbuild` crash on first run due to missing dependencies generated in time.

BTW fix my typo in bluetooth error message formatting.
