### PR TITLE
Better experience on mobile devices

### DIFF
--- a/client/components/layout/nav/Nav.scss
+++ b/client/components/layout/nav/Nav.scss
@@ -10,7 +10,10 @@
 	padding-top: 20px;
 	box-sizing: border-box;
 	width: $navWidth;
-	height: 100vh;
+	height: 100vh; // fallback, eventually should be removed
+	@supports(height: 100dvh) {
+		height: 100dvh;
+	}
 	z-index: 1000;
 	top: 0;
 	left: 0;

--- a/client/components/timer/Timer.scss
+++ b/client/components/timer/Timer.scss
@@ -22,13 +22,17 @@
 	$gridGap: 15px;
 
 	position: relative;
-	height: 100%;
+	height: 100vh; // fallback, eventually should be removed
+	@supports(height: 100dvh) {
+		height: 100dvh;
+	}
 	color: rgb(var(--text-color));
 	margin: 0 auto;
 	display: flex;
 	flex-direction: column;
 	box-sizing: border-box;
 	padding: 0 0 10px 0;
+	padding-bottom: calc(10px + env(safe-area-inset-bottom));
 
 	&__main {
 		position: relative;
@@ -139,7 +143,10 @@
 			top: 55px;
 			padding: 10px !important;
 		}
-
+		height: calc(100vh - 55px); // fallback, eventually should be removed
+		@supports(height: 100dvh) {
+			height: calc(100dvh - 55px);
+		}
 		#{$self}__time {
 			user-select: none;
 

--- a/client/components/timer/Timer.scss
+++ b/client/components/timer/Timer.scss
@@ -40,6 +40,7 @@
 		justify-content: center;
 		align-items: center;
 		width: 100%;
+		user-select: none;
 
 		&-center {
 			width: 100%;

--- a/client/components/timer/header_control/HeaderControl.tsx
+++ b/client/components/timer/header_control/HeaderControl.tsx
@@ -1,4 +1,4 @@
-import React, {useContext} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 import './HeaderControl.scss';
 import {GlobalHotKeys} from 'react-hotkeys';
 import {setCubeType, setSetting} from '../../../db/settings/update';
@@ -20,6 +20,7 @@ import {TIMER_INPUT_TYPE_NAMES} from '../../settings/timer/TimerSettings';
 import {useSettings} from '../../../util/hooks/useSettings';
 import {AllSettings} from '../../../db/settings/query';
 import {useMe} from '../../../util/hooks/useMe';
+import screenfull from '../../../util/vendor/screenfull';
 
 const b = block('timer-header-control');
 
@@ -35,6 +36,16 @@ export default function HeaderControl() {
 	const manualEntry = useSettings('manual_entry');
 	const inspection = useSettings('inspection');
 	const timerType = useSettings('timer_type');
+
+	const [fullScreenMode, setFullScreenMode] = useState(false);
+	if (screenfull.isEnabled) {
+		useEffect(() => {
+			let updateFullScreenState = () => setFullScreenMode(screenfull.isFullscreen);
+			updateFullScreenState();
+			screenfull.on('change', updateFullScreenState);
+			return () => screenfull.off('change', updateFullScreenState);
+		}, []);
+	}
 
 	function toggleCreateNewSession() {
 		dispatch(openModal(<CreateNewSession />));
@@ -116,6 +127,13 @@ export default function HeaderControl() {
 		<Dropdown
 			noMargin
 			options={[
+				{
+					text: 'Full Screen',
+					on: fullScreenMode,
+					hidden: !screenfull.isEnabled,
+					onClick: () => screenfull.toggle(),
+					icon: 'ph-frame-corners',
+				},
 				{
 					text: 'Focus Mode',
 					on: focusMode,

--- a/client/components/timer/time_display/timer_scramble/TimerScramble.scss
+++ b/client/components/timer/time_display/timer_scramble/TimerScramble.scss
@@ -41,6 +41,7 @@
 			color: inherit !important;
 			font-family: inherit;
 			line-height: inherit;
+			z-index: -100;
 		}
 
 		> span {
@@ -75,6 +76,7 @@
 
 	&--edit {
 		border: 2px solid rgba(var(--text-color), 0.2) !important;
+		z-index: 100 !important;
 	}
 
 	&__actions {

--- a/client/util/vendor/screenfull.d.ts
+++ b/client/util/vendor/screenfull.d.ts
@@ -1,0 +1,175 @@
+export type RawEventNames = {
+	readonly requestFullscreen: string;
+	readonly exitFullscreen: string;
+	readonly fullscreenElement: string;
+	readonly fullscreenEnabled: string;
+	readonly fullscreenchange: string;
+	readonly fullscreenerror: string;
+};
+
+export type EventName = 'change' | 'error';
+
+/**
+Simple wrapper for cross-browser usage of the JavaScript [Fullscreen API](https://developer.mozilla.org/en/DOM/Using_full-screen_mode), which lets you bring the page or any element into fullscreen. Smoothens out the browser implementation differences, so you don't have to.
+*/
+declare const screenfull: {
+	/**
+	Whether fullscreen is active.
+	*/
+	readonly isFullscreen: boolean;
+
+	/**
+	The element currently in fullscreen, otherwise `undefined`.
+	*/
+	readonly element: Element | undefined;
+
+	/**
+	Whether you are allowed to enter fullscreen. If your page is inside an `<iframe>` you will need to add a `allowfullscreen` attribute (+ `webkitallowfullscreen` and `mozallowfullscreen`).
+
+	@example
+	```
+	import screenfull from 'screenfull';
+
+	if (screenfull.isEnabled) {
+		screenfull.request();
+	}
+	```
+	*/
+	readonly isEnabled: boolean;
+
+	/**
+	Exposes the raw properties (prefixed if needed) used internally.
+	*/
+	raw: RawEventNames;
+
+	/**
+	Make an element fullscreen.
+
+	If your page is inside an `<iframe>` you will need to add a `allowfullscreen` attribute (+ `webkitallowfullscreen` and `mozallowfullscreen`).
+
+	Keep in mind that the browser will only enter fullscreen when initiated by user events like click, touch, key.
+
+	@param element - Default is `<html>`. If called with another element than the currently active, it will switch to that if it's a descendant.
+	@param options - [`FullscreenOptions`](https://developer.mozilla.org/en-US/docs/Web/API/FullscreenOptions).
+	@returns A promise that resolves after the element enters fullscreen.
+
+	@example
+	```
+	import screenfull from 'screenfull';
+
+	// Fullscreen the page
+	document.getElementById('button').addEventListener('click', () => {
+		if (screenfull.isEnabled) {
+			screenfull.request();
+		} else {
+			// Ignore or do something else
+		}
+	});
+
+	// Fullscreen an element
+	const element = document.getElementById('target');
+
+	document.getElementById('button').addEventListener('click', () => {
+		if (screenfull.isEnabled) {
+			screenfull.request(element);
+		}
+	});
+
+	// Fullscreen an element with options
+	const element = document.getElementById('target');
+
+	document.getElementById('button').addEventListener('click', () => {
+		if (screenfull.isEnabled) {
+			screenfull.request(element, {navigationUI: 'hide'});
+		}
+	});
+
+	// Fullscreen an element with jQuery
+	const element = $('#target')[0]; // Get DOM element from jQuery collection
+
+	$('#button').on('click', () => {
+		if (screenfull.isEnabled) {
+			screenfull.request(element);
+		}
+	});
+	```
+	*/
+	request(element?: Element, options?: FullscreenOptions): Promise<void>;
+
+	/**
+	Brings you out of fullscreen.
+
+	@returns A promise that resolves after the element exits fullscreen.
+	*/
+	exit(): Promise<void>;
+
+	/**
+	Requests fullscreen if not active, otherwise exits.
+
+	@param element - The default is `<html>`. If called with another element than the currently active, it will switch to that if it's a descendant.
+	@param options - [`FullscreenOptions`](https://developer.mozilla.org/en-US/docs/Web/API/FullscreenOptions).
+	@returns A promise that resolves after the element enters/exits fullscreen.
+
+	@example
+	```
+	import screenfull from 'screenfull';
+
+	// Toggle fullscreen on a image with jQuery
+
+	$('img').on('click', event => {
+		if (screenfull.isEnabled) {
+			screenfull.toggle(event.target);
+		}
+	});
+	```
+	*/
+	toggle(element?: Element, options?: FullscreenOptions): Promise<void>;
+
+	/**
+	Add a listener for when the browser switches in and out of fullscreen or when there is an error.
+
+	@example
+	```
+	import screenfull from 'screenfull';
+
+	// Detect fullscreen change
+	if (screenfull.isEnabled) {
+		screenfull.on('change', () => {
+			console.log('Am I fullscreen?', screenfull.isFullscreen ? 'Yes' : 'No');
+		});
+	}
+
+	// Detect fullscreen error
+	if (screenfull.isEnabled) {
+		screenfull.on('error', event => {
+			console.error('Failed to enable fullscreen', event);
+		});
+	}
+	```
+	*/
+	on(name: EventName, handler: (event: Event) => void): void;
+
+	/**
+	Remove a previously registered event listener.
+
+	@example
+	```
+	import screenfull from 'screenfull';
+
+	screenfull.off('change', callback);
+	```
+	*/
+	off(name: EventName, handler: (event: Event) => void): void;
+
+	/**
+	Alias for `.on('change', function)`.
+	*/
+	onchange(handler: (event: Event) => void): void;
+
+	/**
+	Alias for `.on('error', function)`.
+	*/
+	onerror(handler: (event: Event) => void): void;
+};
+
+export default screenfull;

--- a/client/util/vendor/screenfull.js
+++ b/client/util/vendor/screenfull.js
@@ -1,0 +1,160 @@
+/* eslint-disable promise/prefer-await-to-then */
+
+const methodMap = [
+	[
+		'requestFullscreen',
+		'exitFullscreen',
+		'fullscreenElement',
+		'fullscreenEnabled',
+		'fullscreenchange',
+		'fullscreenerror',
+	],
+	// New WebKit
+	[
+		'webkitRequestFullscreen',
+		'webkitExitFullscreen',
+		'webkitFullscreenElement',
+		'webkitFullscreenEnabled',
+		'webkitfullscreenchange',
+		'webkitfullscreenerror',
+
+	],
+	// Old WebKit
+	[
+		'webkitRequestFullScreen',
+		'webkitCancelFullScreen',
+		'webkitCurrentFullScreenElement',
+		'webkitCancelFullScreen',
+		'webkitfullscreenchange',
+		'webkitfullscreenerror',
+
+	],
+	[
+		'mozRequestFullScreen',
+		'mozCancelFullScreen',
+		'mozFullScreenElement',
+		'mozFullScreenEnabled',
+		'mozfullscreenchange',
+		'mozfullscreenerror',
+	],
+	[
+		'msRequestFullscreen',
+		'msExitFullscreen',
+		'msFullscreenElement',
+		'msFullscreenEnabled',
+		'MSFullscreenChange',
+		'MSFullscreenError',
+	],
+];
+
+const nativeAPI = (() => {
+	if (typeof document === 'undefined') {
+		return false;
+	}
+
+	const unprefixedMethods = methodMap[0];
+	const returnValue = {};
+
+	for (const methodList of methodMap) {
+		const exitFullscreenMethod = methodList?.[1];
+		if (exitFullscreenMethod in document) {
+			for (const [index, method] of methodList.entries()) {
+				returnValue[unprefixedMethods[index]] = method;
+			}
+
+			return returnValue;
+		}
+	}
+
+	return false;
+})();
+
+const eventNameMap = {
+	change: nativeAPI.fullscreenchange,
+	error: nativeAPI.fullscreenerror,
+};
+
+// eslint-disable-next-line import/no-mutable-exports
+let screenfull = {
+	// eslint-disable-next-line default-param-last
+	request(element = document.documentElement, options) {
+		return new Promise((resolve, reject) => {
+			const onFullScreenEntered = () => {
+				screenfull.off('change', onFullScreenEntered);
+				resolve();
+			};
+
+			screenfull.on('change', onFullScreenEntered);
+
+			const returnPromise = element[nativeAPI.requestFullscreen](options);
+
+			if (returnPromise instanceof Promise) {
+				returnPromise.then(onFullScreenEntered).catch(reject);
+			}
+		});
+	},
+	exit() {
+		return new Promise((resolve, reject) => {
+			if (!screenfull.isFullscreen) {
+				resolve();
+				return;
+			}
+
+			const onFullScreenExit = () => {
+				screenfull.off('change', onFullScreenExit);
+				resolve();
+			};
+
+			screenfull.on('change', onFullScreenExit);
+
+			const returnPromise = document[nativeAPI.exitFullscreen]();
+
+			if (returnPromise instanceof Promise) {
+				returnPromise.then(onFullScreenExit).catch(reject);
+			}
+		});
+	},
+	toggle(element, options) {
+		return screenfull.isFullscreen ? screenfull.exit() : screenfull.request(element, options);
+	},
+	onchange(callback) {
+		screenfull.on('change', callback);
+	},
+	onerror(callback) {
+		screenfull.on('error', callback);
+	},
+	on(event, callback) {
+		const eventName = eventNameMap[event];
+		if (eventName) {
+			document.addEventListener(eventName, callback, false);
+		}
+	},
+	off(event, callback) {
+		const eventName = eventNameMap[event];
+		if (eventName) {
+			document.removeEventListener(eventName, callback, false);
+		}
+	},
+	raw: nativeAPI,
+};
+
+Object.defineProperties(screenfull, {
+	isFullscreen: {
+		get: () => Boolean(document[nativeAPI.fullscreenElement]),
+	},
+	element: {
+		enumerable: true,
+		get: () => document[nativeAPI.fullscreenElement] ?? undefined,
+	},
+	isEnabled: {
+		enumerable: true,
+		// Coerce to boolean in case of old WebKit.
+		get: () => Boolean(document[nativeAPI.fullscreenEnabled]),
+	},
+});
+
+if (!nativeAPI) {
+	screenfull = {isEnabled: false};
+}
+
+export default screenfull;


### PR DESCRIPTION
1. Added `Full Screen` button.
 
   Wanted to be implemented using [screenfull](https://www.npmjs.com/package/screenfull) npm library. But due to ESM loader issues in `ts-node-dev` for now pure ESM modules can't be used even in client code. Although `ts-node` supports them via `ts-node/esm` loader, `ts-node-dev` does not respect it.

   So for now just put `screenfull` library as vendor code right in the Cubedesk codebase.

2. Fix 100vh height for mobile devices that does not respect dynamic toolbars. Just look at screenshots from iPad and Android phone:

    | Before | After |
    | ------ | ----- |
    |<img src="https://user-images.githubusercontent.com/4266693/224285494-a85ab8bd-23f5-4936-b25b-7aa664a8f305.PNG" width="300" title="Before">|<img src="https://user-images.githubusercontent.com/4266693/224285513-9bee5a93-dc98-49ab-a630-50c0c4fafb2f.PNG" width="300" title="After">|
    |<img src="https://user-images.githubusercontent.com/4266693/224285540-272844f7-3f1b-4170-a745-36460fa50ff8.jpg" width="300" title="Before">|<img src="https://user-images.githubusercontent.com/4266693/224285542-f0525d5f-0b7f-4600-bc30-264346745780.jpg" width="300" title="After">|

    More readings on topic:
    - https://stackoverflow.com/questions/37112218/css3-100vh-not-constant-in-mobile-browser
    - https://web.dev/viewport-units/
    - https://github.com/web-platform-tests/interop-2022-viewport/blob/main/explainers/viewport-units.md


5. Got rid of annoying text selection which popups when using timer on touch devices especially with bigger screens like iPad.

    https://user-images.githubusercontent.com/4266693/224285521-a17d10a3-a8bd-4e81-9556-7b4f1aa2aff6.mp4
