### PR TITLE
Fix functionality of some GAN Smart Timers on macOS

### DIFF
--- a/client/components/timer/smart_cube/bluetooth/connect.js
+++ b/client/components/timer/smart_cube/bluetooth/connect.js
@@ -18,6 +18,7 @@ export default class Connect extends SmartCube {
 					{namePrefix: 'Mi Smart Magic Cube'},
 					{namePrefix: 'GAN'},
 					{namePrefix: 'Gan'},
+					{namePrefix: 'gan'},
 					{namePrefix: 'GoCube'},
 					{namePrefix: 'Rubiks'},
 


### PR DESCRIPTION
On macOS, the standard GanTimer (not the Halo Smart Timer) device seems to be detected with the prefix "gan". However, not including this prefix (as CubeDesk currently does) causes the timer to not be detected. This PR adds the required prefix for full functionality of the GanTimer on macOS.