### PR TITLE
Store locked scramble in user setting & reset editScramble to false when lock scramble

### DIFF
--- a/client/components/timer/time_display/timer_scramble/TimerScramble.tsx
+++ b/client/components/timer/time_display/timer_scramble/TimerScramble.tsx
@@ -45,6 +45,9 @@ export default function TimerScramble() {
 	}, [cubeType, sessionId]);
 
 	function toggleScrambleLock() {
+		if (editScramble) {
+			setTimerParam('editScramble', false);
+		}
 		setTimerParam('scrambleLocked', !scrambleLocked);
 
 		const lockedScramble = scrambleLocked ? null : scramble;

--- a/client/components/timer/time_display/timer_scramble/TimerScramble.tsx
+++ b/client/components/timer/time_display/timer_scramble/TimerScramble.tsx
@@ -67,7 +67,6 @@ export default function TimerScramble() {
 
 	function handleScrambleChange(e) {
 		e.preventDefault();
-
 		setTimerParam('scramble', e.target.value);
 	}
 

--- a/client/components/timer/time_display/timer_scramble/TimerScramble.tsx
+++ b/client/components/timer/time_display/timer_scramble/TimerScramble.tsx
@@ -13,6 +13,7 @@ import SmartScramble from './smart_scramble/SmartScramble';
 import {setTimerParam} from '../../helpers/params';
 import {smartCubeSelected} from '../../helpers/util';
 import {useSettings} from '../../../../util/hooks/useSettings';
+import {setSetting} from '../../../../db/settings/update';
 
 const b = block('timer-scramble');
 
@@ -32,13 +33,23 @@ export default function TimerScramble() {
 
 	const {editScramble, scrambleLocked, notification, hideScramble, timeStartedAt} = context;
 	let scramble = context.scramble;
+	const lockedScramble = useSettings('locked_scramble');
 
 	useEffect(() => {
-		resetScramble(context);
+		if (lockedScramble && !timeStartedAt) {
+			setTimerParam('scramble', lockedScramble);
+			setTimerParam('scrambleLocked', true);
+		} else {
+			resetScramble(context);
+		}
 	}, [cubeType, sessionId]);
 
 	function toggleScrambleLock() {
 		setTimerParam('scrambleLocked', !scrambleLocked);
+
+		const lockedScramble = scrambleLocked ? null : scramble;
+
+		setSetting('locked_scramble', lockedScramble);
 	}
 
 	function toggleEditScramble() {
@@ -53,6 +64,7 @@ export default function TimerScramble() {
 
 	function handleScrambleChange(e) {
 		e.preventDefault();
+
 		setTimerParam('scramble', e.target.value);
 	}
 

--- a/client/db/settings/query.ts
+++ b/client/db/settings/query.ts
@@ -27,6 +27,7 @@ export interface AllSettings {
 	cube_type: string;
 	session_id: string;
 	custom_cube_types: CustomCubeType[];
+	locked_scramble: string;
 
 	// Local
 	timer_type: 'keyboard' | 'smart' | 'stackmat' | 'gantimer';
@@ -75,6 +76,7 @@ const defaultSettings: AllSettings = {
 	beta_tester: false,
 	cube_type: '333',
 	session_id: null,
+	locked_scramble: null,
 	custom_cube_types: [],
 
 	timer_type: 'keyboard',


### PR DESCRIPTION
There are two changes:

1. Store the locked scramble so that it could be used across refresh and devices
2. Reset the editScramble to false when lock scramble

Screencast: 

https://github.com/user-attachments/assets/cf0cc8b2-59ad-4bcf-97cb-8f3bbd0b5e24


