### PR TITLE
Fix grey-screen crash from orphaned timer module settings (#193)

### DIFF
--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -1,3 +1,4 @@
+import ErrorBoundary from '@/components/common/ErrorBoundary';
 import {routes} from '@/components/layout/Routes';
 import 'seedrandom';
 import {setStore} from '@/components/store';
@@ -43,7 +44,9 @@ const tree = (
 		<HelmetProvider>
 			<Provider store={store as any}>
 				<BrowserRouter>
-					<Switch>{routes.map((route) => mapSingleRoute(route))}</Switch>
+					<ErrorBoundary>
+						<Switch>{routes.map((route) => mapSingleRoute(route))}</Switch>
+					</ErrorBoundary>
 				</BrowserRouter>
 			</Provider>
 		</HelmetProvider>

--- a/client/components/common/ErrorBoundary.tsx
+++ b/client/components/common/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import Button from '@/components/common/Button';
+import * as Sentry from '@sentry/browser';
+import React, {ErrorInfo, ReactNode} from 'react';
+
+interface Props {
+	children: ReactNode;
+}
+
+interface State {
+	error: Error | null;
+}
+
+// The app previously had no error boundary anywhere, so any uncaught render error (see #193)
+// unmounted the entire React tree with no fallback, leaving a blank/grey page that only a full
+// refresh could recover from. This catches those errors, reports them to Sentry so the exact
+// trigger can be diagnosed, and shows a recoverable screen instead of a silent crash.
+export default class ErrorBoundary extends React.Component<Props, State> {
+	state: State = {error: null};
+
+	static getDerivedStateFromError(error: Error): State {
+		return {error};
+	}
+
+	componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+		Sentry.captureException(error, {
+			contexts: {
+				react: {componentStack: errorInfo.componentStack},
+			},
+		});
+	}
+
+	render() {
+		if (this.state.error) {
+			return (
+				<div className="flex h-screen w-screen flex-col items-center justify-center gap-4 bg-background p-8 text-center text-text">
+					<h1 className="text-2xl font-semibold">Something went wrong</h1>
+					<p className="max-w-md text-text/70">
+						An unexpected error occurred. If you were in the middle of a solve, it may not have been saved.
+						Reloading the page should fix it.
+					</p>
+					<Button primary large text="Reload page" onClick={() => window.location.reload()} />
+				</div>
+			);
+		}
+
+		return this.props.children;
+	}
+}

--- a/client/components/timer/footer/TimerModule.tsx
+++ b/client/components/timer/footer/TimerModule.tsx
@@ -8,6 +8,7 @@ import TimeChart from '@/components/modules/time-chart/TimeChart';
 import TimeDistro from '@/components/modules/time-distro/TimeDistro';
 import {TimerModuleDropdownOptions, TimerModuleType} from '@/components/timer/@types/enums';
 import {FooterModuleData, TimerCustomModuleOptions} from '@/components/timer/@types/interfaces';
+import {resolveModuleVisual} from '@/components/timer/footer/helpers/resolveModuleVisual';
 import {useTimerContext} from '@/components/timer/Timer';
 import {setSetting} from '@/db/settings/update';
 import {useGeneral} from '@/util/hooks/useGeneral';
@@ -92,7 +93,7 @@ export default function TimerModule(props: Props) {
 		visual = customOptions.customBody(context);
 	} else {
 		const visualType = customOptions?.moduleType || snakeCase(moduleType ?? '');
-		visual = moduleMap[visualType];
+		visual = resolveModuleVisual(moduleMap, visualType, {module: null});
 	}
 
 	let dropdown: ReactNode = (

--- a/client/components/timer/footer/helpers/resolveModuleVisual.test.ts
+++ b/client/components/timer/footer/helpers/resolveModuleVisual.test.ts
@@ -1,0 +1,23 @@
+import {resolveModuleVisual} from '@/components/timer/footer/helpers/resolveModuleVisual';
+
+describe('resolveModuleVisual', () => {
+	type ModuleData = {module: string | null};
+	const fallback: ModuleData = {module: null};
+
+	it('returns the matching entry for a known module type', () => {
+		const moduleMap: Record<string, ModuleData> = {history: {module: 'history-module'}};
+
+		expect(resolveModuleVisual(moduleMap, 'history', fallback)).toEqual({module: 'history-module'});
+	});
+
+	// Regression test for #193 ("the screen goes grey mid solve randomly"): a user with a
+	// legacy `timer_modules` value referencing a since-removed module type (e.g. the old
+	// "chat" module) would get `undefined` back here. TimerModule then dereferenced
+	// `visual.module` on that `undefined`, throwing during render with no error boundary
+	// to catch it, which unmounted the whole app and left a blank/grey screen.
+	it('falls back instead of returning undefined for an orphaned/unknown module type', () => {
+		const moduleMap: Record<string, ModuleData> = {history: {module: 'history-module'}};
+
+		expect(resolveModuleVisual(moduleMap, 'chat', fallback)).toEqual(fallback);
+	});
+});

--- a/client/components/timer/footer/helpers/resolveModuleVisual.ts
+++ b/client/components/timer/footer/helpers/resolveModuleVisual.ts
@@ -1,0 +1,8 @@
+// Some `TimerModuleType` values (e.g. `TRAINER_ALGO`, `SESSION_STATS`, `CHAT`) belong to
+// features that were removed and no longer have an entry in every module map. Users who
+// selected one of those modules before it was removed still have the value persisted in
+// their `timer_modules` setting, so a plain `moduleMap[visualType]` lookup can come back
+// `undefined`. Falling back keeps that footer slot blank instead of throwing during render.
+export function resolveModuleVisual<T>(moduleMap: Partial<Record<string, T>>, visualType: string, fallback: T): T {
+	return moduleMap[visualType] ?? fallback;
+}

--- a/client/components/timer/helpers/pb.ts
+++ b/client/components/timer/helpers/pb.ts
@@ -11,18 +11,18 @@ import confetti from 'canvas-confetti';
 let lastConfetti: Date | null = null;
 
 export function listenForPbEvents(context: ITimerContext) {
-	if (context.ignorePbEvents) {
-		return;
-	}
+	const ignorePbEvents = !!context.ignorePbEvents;
 
 	// In case the user doesn't have Quick Stats selected, we need to fetch the single and average PB so that it can be
 	// find in the cache
-	const pbFilter: FilterSolvesOptions = {
-		cube_type: context.cubeType,
-	};
+	if (!ignorePbEvents) {
+		const pbFilter: FilterSolvesOptions = {
+			cube_type: context.cubeType,
+		};
 
-	getSinglePB(pbFilter);
-	getAveragePB(pbFilter, 5);
+		getSinglePB(pbFilter);
+		getAveragePB(pbFilter, 5);
+	}
 
 	function pbEventCallback(msg: string) {
 		triggerConfetti();
@@ -32,31 +32,38 @@ export function listenForPbEvents(context: ITimerContext) {
 		});
 	}
 
+	// These hooks must always be called, in the same order, regardless of `ignorePbEvents` -
+	// conditionally calling hooks based on a prop that can change between renders of the same
+	// component violates the Rules of Hooks and throws "Rendered fewer/more hooks than during
+	// the previous render", crashing the whole app since there's no error boundary to catch it.
 	useEventListener(
 		'singlePbEvent',
 		(ct) => {
+			if (ignorePbEvents) return;
 			const cubeType = getCubeTypeInfoById(ct);
 			pbEventCallback(`New ${cubeType?.name ?? ct} Single PB!`);
 		},
-		[context.cubeType]
+		[context.cubeType, ignorePbEvents]
 	);
 
 	useEventListener(
 		'avgPbEvent',
 		(ct) => {
+			if (ignorePbEvents) return;
 			const cubeType = getCubeTypeInfoById(ct);
 			pbEventCallback(`New ${cubeType?.name ?? ct} Average of 5 PB!`);
 		},
-		[context.cubeType]
+		[context.cubeType, ignorePbEvents]
 	);
 
 	useEventListener(
 		'singleAndAvgPbEvent',
 		(ct) => {
+			if (ignorePbEvents) return;
 			const cubeType = getCubeTypeInfoById(ct);
 			pbEventCallback(`New ${cubeType?.name ?? ct} Single and Average of 5 PB!`);
 		},
-		[context.cubeType]
+		[context.cubeType, ignorePbEvents]
 	);
 }
 


### PR DESCRIPTION
TimerModule looked up its footer module via an unguarded moduleMap[visualType] and dereferenced .module on the result. TimerModuleType still declares TRAINER_ALGO, SESSION_STATS, and CHAT from features removed before this repo's history began, but the default moduleMap never implemented them. Any account with a persisted timer_modules setting referencing one of those throws a TypeError during render. With no error boundary anywhere in the app, that uncaught error unmounted the whole React tree, leaving a blank/ grey screen that only a full refresh could clear.

Adds a safe fallback lookup (resolveModuleVisual), a top-level ErrorBoundary as a safety net for any future render crash, and fixes a Rules-of-Hooks violation in listenForPbEvents found in the same code path.