### PR TITLE
Fix GAN Smart Timer failing to connect

### DIFF
--- a/client/@types/client.d.ts
+++ b/client/@types/client.d.ts
@@ -13,10 +13,27 @@ interface BluetoothRequestDeviceFilter {
 	namePrefix?: string;
 }
 
+interface BluetoothRemoteGATTCharacteristic extends EventTarget {
+	uuid: string;
+	value?: DataView;
+	readValue(): Promise<DataView>;
+	writeValue(value: BufferSource): Promise<void>;
+	startNotifications(): Promise<BluetoothRemoteGATTCharacteristic>;
+	stopNotifications(): Promise<BluetoothRemoteGATTCharacteristic>;
+}
+
+interface BluetoothRemoteGATTService {
+	uuid: string;
+	getCharacteristic(characteristic: string): Promise<BluetoothRemoteGATTCharacteristic>;
+	getCharacteristics(characteristic?: string): Promise<BluetoothRemoteGATTCharacteristic[]>;
+}
+
 interface BluetoothRemoteGATTServer {
 	connected: boolean;
 	connect(): Promise<BluetoothRemoteGATTServer>;
 	disconnect(): void;
+	getPrimaryService(service: string): Promise<BluetoothRemoteGATTService>;
+	getPrimaryServices(service?: string): Promise<BluetoothRemoteGATTService[]>;
 }
 
 interface BluetoothDevice extends EventTarget {

--- a/client/components/timer/common/GanTimerErrorMessage.tsx
+++ b/client/components/timer/common/GanTimerErrorMessage.tsx
@@ -1,0 +1,35 @@
+import ModalHeader from '@/components/common/modal/ModalHeader';
+import React from 'react';
+
+interface Props {
+	message: string;
+}
+
+export default function GanTimerErrorMessage({message}: Props) {
+	const title = <span style={{color: 'rgb(var(--error-color))'}}>Could not connect to timer</span>;
+	const description = <span style={{color: 'rgb(var(--warning-color))'}}>{message}</span>;
+
+	return (
+		<>
+			<ModalHeader title={title} description={description} />
+			<p>
+				Things worth trying:
+				<ul style={{listStyle: 'disc', margin: '1em', paddingLeft: '1em'}}>
+					<li>Turn the timer off and back on, then connect again.</li>
+					<li>
+						Close any other tab or app that is connected to the timer. A GAN Smart Timer
+						only talks to one at a time.
+					</li>
+					<li>
+						Remove the timer from your operating system&apos;s Bluetooth settings if you
+						paired it there, then retry. It should be paired from the browser, not the OS.
+					</li>
+					<li>
+						On Chrome, visit <code>chrome://bluetooth-internals</code> to confirm the
+						timer is advertising.
+					</li>
+				</ul>
+			</p>
+		</>
+	);
+}

--- a/client/components/timer/time-display/GanTimer.tsx
+++ b/client/components/timer/time-display/GanTimer.tsx
@@ -1,6 +1,7 @@
 import {openModal} from '@/actions/general';
 import Emblem from '@/components/common/Emblem';
 import BluetoothErrorMessage from '@/components/timer/common/BluetoothErrorMessage';
+import GanTimerErrorMessage from '@/components/timer/common/GanTimerErrorMessage';
 import {
 	cancelInspection,
 	endTimer,
@@ -8,11 +9,16 @@ import {
 	startTimer,
 } from '@/components/timer/helpers/events';
 import {setTimerParams} from '@/components/timer/helpers/params';
+import {
+	connectGanTimer,
+	GanTimerConnection,
+	GanTimerConnectionError,
+} from '@/components/timer/time-display/gan-timer/connect';
+import {GanTimerEvent, GanTimerState} from '@/components/timer/time-display/gan-timer/protocol';
 import {ITimerContext, useTimerContext} from '@/components/timer/Timer';
 import {useSettings} from '@/util/hooks/useSettings';
-import {connectGanTimer, GanTimerConnection, GanTimerEvent, GanTimerState} from 'gan-web-bluetooth';
 import {Bluetooth} from 'phosphor-react';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useDispatch} from 'react-redux';
 import {SubscriptionLike} from 'rxjs';
 
@@ -25,20 +31,14 @@ let subs: SubscriptionLike | null = null;
 export default function GanTimer() {
 	const dispatch = useDispatch();
 	const inspectionEnabled = useSettings('inspection');
-	const [connected, setConnected] = useState(false);
+	const [connected, setConnected] = useState(!!conn);
+	const [connecting, setConnecting] = useState(false);
 
 	const context = useTimerContext();
 	const contextRef = useRef<ITimerContext>(context);
 	useEffect(() => {
 		contextRef.current = context;
 	}, [context]);
-
-	// Subscribe/unsubscribe to GAN Smart Timer events when component being mounted/unmounted
-	useEffect(() => {
-		subs = conn?.events$.subscribe(handleTimerEvent) ?? null;
-		setConnected(!!conn);
-		return () => subs?.unsubscribe();
-	}, []);
 
 	function handleTimerEvent(event: GanTimerEvent) {
 		switch (event.state) {
@@ -60,6 +60,9 @@ export default function GanTimer() {
 					endTimer(contextRef.current, event.recordedTime.asTimestamp);
 				}
 				break;
+			case GanTimerState.FINISHED:
+				// Emitted immediately after STOPPED, which already recorded the solve.
+				break;
 			case GanTimerState.IDLE:
 				if (
 					!inspectionEnabled ||
@@ -73,39 +76,100 @@ export default function GanTimer() {
 				}
 				break;
 			case GanTimerState.DISCONNECT:
+				conn = null;
 				setConnected(false);
 				break;
 		}
 	}
 
+	// The subscription outlives individual renders, so route events through a ref.
+	// Reading the handler off the ref keeps settings like inspection up to date
+	// instead of freezing whatever they were when the timer was connected.
+	const handlerRef = useRef(handleTimerEvent);
+	handlerRef.current = handleTimerEvent;
+
+	const subscribe = useCallback((connection: GanTimerConnection): SubscriptionLike => {
+		return connection.events$.subscribe({
+			next: (event: GanTimerEvent) => handlerRef.current(event),
+			// The driver drops bad packets rather than erroring, but never let an
+			// unexpected stream error escape as an unhandled rejection.
+			error: (err: unknown) => {
+				console.error('[GanTimer] event stream error', err);
+				conn = null;
+				setConnected(false);
+			},
+		});
+	}, []);
+
+	// Re-attach to an existing connection when this component is remounted
+	useEffect(() => {
+		subs?.unsubscribe();
+		subs = conn ? subscribe(conn) : null;
+		setConnected(!!conn);
+		return () => subs?.unsubscribe();
+	}, [subscribe]);
+
 	async function handleConnectButton() {
+		if (connecting) {
+			return;
+		}
+
 		if (conn) {
-			conn.disconnect();
+			const closing = conn;
 			conn = null;
+			subs?.unsubscribe();
+			subs = null;
 			setConnected(false);
-		} else {
+			await closing.disconnect().catch(() => undefined);
+			return;
+		}
+
+		setConnecting(true);
+		try {
 			const bluetoothAvailable =
 				!!navigator.bluetooth && (await navigator.bluetooth.getAvailability());
-			if (bluetoothAvailable) {
-				conn = await connectGanTimer();
-				conn.events$.subscribe(
-					(evt) => evt.state == GanTimerState.DISCONNECT && (conn = null),
-				);
-				subs = conn.events$.subscribe(handleTimerEvent);
-				setConnected(true);
-			} else {
+			if (!bluetoothAvailable) {
 				dispatch(openModal(<BluetoothErrorMessage />));
+				return;
 			}
+
+			const connection = await connectGanTimer();
+			conn = connection;
+			subs?.unsubscribe();
+			subs = subscribe(connection);
+			setConnected(true);
+		} catch (err) {
+			conn = null;
+			setConnected(false);
+
+			// The user just closed the browser's device chooser; nothing to report.
+			if (err instanceof GanTimerConnectionError && err.cancelled) {
+				return;
+			}
+
+			console.error('[GanTimer] connection failed', err);
+			const message =
+				err instanceof Error ? err.message : 'An unknown error occurred while connecting.';
+			dispatch(openModal(<GanTimerErrorMessage message={message} />));
+		} finally {
+			setConnecting(false);
 		}
+	}
+
+	let text = 'Connect to Timer';
+	if (connecting) {
+		text = 'Connecting...';
+	} else if (connected) {
+		text = 'Connected';
 	}
 
 	return (
 		<div onClick={handleConnectButton} style={{userSelect: 'none', cursor: 'pointer'}}>
 			<Emblem
 				icon={<Bluetooth />}
-				text={connected ? 'Connected' : 'Connect to Timer'}
+				text={text}
 				small
-				red={!connected}
+				red={!connected && !connecting}
 				green={connected}
 			/>
 		</div>

--- a/client/components/timer/time-display/gan-timer/connect.test.ts
+++ b/client/components/timer/time-display/gan-timer/connect.test.ts
@@ -1,0 +1,341 @@
+import {
+	connectGanTimer,
+	GAN_TIMER_SERVICE,
+	GAN_TIMER_STATE_CHARACTERISTIC,
+	GAN_TIMER_TIME_CHARACTERISTIC,
+	GanTimerConnectionError,
+} from '@/components/timer/time-display/gan-timer/connect';
+import {crc16ccit, GanTimerState} from '@/components/timer/time-display/gan-timer/protocol';
+
+function buildPacket(state: number, payload: number[] = []): DataView {
+	const body = [0xfe, 0x00, 0x00, state, ...payload];
+	const crc = crc16ccit(new Uint8Array(body.slice(2)).buffer);
+	return new DataView(new Uint8Array([...body, crc & 0xff, (crc >> 8) & 0xff]).buffer);
+}
+
+class FakeCharacteristic {
+	uuid: string;
+	listeners: ((evt: {target: {value: DataView}}) => void)[] = [];
+	startNotifications = jest.fn().mockResolvedValue(undefined);
+	stopNotifications = jest.fn().mockResolvedValue(undefined);
+	readValue = jest.fn();
+
+	constructor(uuid: string) {
+		this.uuid = uuid;
+	}
+
+	addEventListener(_type: string, cb: (evt: {target: {value: DataView}}) => void) {
+		this.listeners.push(cb);
+	}
+
+	removeEventListener(_type: string, cb: (evt: {target: {value: DataView}}) => void) {
+		this.listeners = this.listeners.filter((l) => l !== cb);
+	}
+
+	/** Simulate the timer pushing a notification */
+	emit(value: DataView) {
+		this.listeners.forEach((cb) => cb({target: {value}}));
+	}
+}
+
+interface FakeServiceOptions {
+	uuid?: string;
+	characteristics?: string[];
+	failGetCharacteristic?: string[];
+}
+
+class FakeService {
+	uuid: string;
+	characteristics = new Map<string, FakeCharacteristic>();
+	private failFor: string[];
+
+	constructor({uuid = GAN_TIMER_SERVICE, characteristics, failGetCharacteristic = []}: FakeServiceOptions = {}) {
+		this.uuid = uuid;
+		this.failFor = failGetCharacteristic;
+		const uuids = characteristics ?? [GAN_TIMER_TIME_CHARACTERISTIC, GAN_TIMER_STATE_CHARACTERISTIC];
+		uuids.forEach((u) => this.characteristics.set(u, new FakeCharacteristic(u)));
+	}
+
+	async getCharacteristic(uuid: string) {
+		if (this.failFor.includes(uuid)) {
+			throw new Error(`No Characteristics matching UUID ${uuid} found in Service.`);
+		}
+		const chr = this.characteristics.get(uuid);
+		if (!chr) {
+			throw new Error(`No Characteristics matching UUID ${uuid} found in Service.`);
+		}
+		return chr;
+	}
+}
+
+interface FakeDeviceOptions {
+	services?: FakeService[];
+	/** Number of getPrimaryService calls that should fail before succeeding */
+	primaryServiceFailures?: number;
+	/** Make getPrimaryService always fail, forcing the getPrimaryServices fallback */
+	primaryServiceAlwaysFails?: boolean;
+	gattConnectFailures?: number;
+}
+
+class FakeDevice {
+	name = 'GAN Timer';
+	listeners: Record<string, (() => void)[]> = {};
+	gatt: {
+		connected: boolean;
+		connect: jest.Mock;
+		disconnect: jest.Mock;
+		getPrimaryService: jest.Mock;
+		getPrimaryServices: jest.Mock;
+	};
+
+	constructor(options: FakeDeviceOptions = {}) {
+		const services = options.services ?? [new FakeService()];
+		let primaryServiceCalls = 0;
+		let gattConnectCalls = 0;
+
+		this.gatt = {
+			connected: false,
+			connect: jest.fn(async () => {
+				gattConnectCalls++;
+				if (gattConnectCalls <= (options.gattConnectFailures ?? 0)) {
+					throw new Error('GATT operation failed for unknown reason.');
+				}
+				this.gatt.connected = true;
+				return this.gatt;
+			}),
+			disconnect: jest.fn(() => {
+				this.gatt.connected = false;
+			}),
+			getPrimaryService: jest.fn(async (uuid: string) => {
+				primaryServiceCalls++;
+				if (
+					options.primaryServiceAlwaysFails ||
+					primaryServiceCalls <= (options.primaryServiceFailures ?? 0)
+				) {
+					throw new Error(`No Services matching UUID ${uuid} found in Device.`);
+				}
+				const svc = services.find((s) => s.uuid === uuid);
+				if (!svc) {
+					throw new Error(`No Services matching UUID ${uuid} found in Device.`);
+				}
+				return svc;
+			}),
+			getPrimaryServices: jest.fn(async () => services),
+		};
+	}
+
+	addEventListener(type: string, cb: () => void) {
+		(this.listeners[type] ??= []).push(cb);
+	}
+
+	removeEventListener(type: string, cb: () => void) {
+		this.listeners[type] = (this.listeners[type] ?? []).filter((l) => l !== cb);
+	}
+
+	emit(type: string) {
+		[...(this.listeners[type] ?? [])].forEach((cb) => cb());
+	}
+}
+
+/** Node exposes `navigator` as a non-writable accessor, so redefine it outright */
+function setNavigator(value: unknown) {
+	Object.defineProperty(global, 'navigator', {value, configurable: true, writable: true});
+}
+
+function mockBluetooth(device: FakeDevice, requestDevice?: jest.Mock) {
+	const request = requestDevice ?? jest.fn().mockResolvedValue(device);
+	setNavigator({
+		bluetooth: {
+			getAvailability: jest.fn().mockResolvedValue(true),
+			requestDevice: request,
+		},
+	});
+	return request;
+}
+
+// Zero delay so the retry paths don't slow the suite down
+const options = {retryDelayMs: 0};
+
+describe('connectGanTimer', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('offers the timer service as a device filter, not just name prefixes', async () => {
+		const device = new FakeDevice();
+		const requestDevice = mockBluetooth(device);
+
+		await connectGanTimer(options);
+
+		const filters = requestDevice.mock.calls[0][0].filters;
+		expect(filters).toEqual(
+			expect.arrayContaining([
+				{namePrefix: 'GAN'},
+				{namePrefix: 'Gan'},
+				{namePrefix: 'gan'},
+				{services: [GAN_TIMER_SERVICE]},
+			])
+		);
+		expect(requestDevice.mock.calls[0][0].optionalServices).toContain(GAN_TIMER_SERVICE);
+	});
+
+	it('connects when the timer only exposes the state characteristic', async () => {
+		// The time characteristic is optional: CubeDesk never reads recorded times,
+		// so a timer that does not expose fff2 must still connect.
+		const service = new FakeService({characteristics: [GAN_TIMER_STATE_CHARACTERISTIC]});
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+
+		expect(conn).toBeTruthy();
+		await expect(conn.getRecordedTimes()).rejects.toBeInstanceOf(GanTimerConnectionError);
+	});
+
+	it('retries service discovery when the first lookup fails', async () => {
+		const device = new FakeDevice({primaryServiceFailures: 2});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+
+		expect(conn).toBeTruthy();
+		expect(device.gatt.getPrimaryService).toHaveBeenCalledTimes(3);
+	});
+
+	it('falls back to enumerating services when lookup by UUID never succeeds', async () => {
+		// Chrome on macOS can report the service with a different UUID casing or
+		// refuse a direct lookup while still listing it.
+		const service = new FakeService({uuid: GAN_TIMER_SERVICE.toUpperCase()});
+		const device = new FakeDevice({services: [service], primaryServiceAlwaysFails: true});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+
+		expect(conn).toBeTruthy();
+		expect(device.gatt.getPrimaryServices).toHaveBeenCalled();
+	});
+
+	it('retries a failed GATT connection', async () => {
+		const device = new FakeDevice({gattConnectFailures: 1});
+		mockBluetooth(device);
+
+		await connectGanTimer(options);
+
+		expect(device.gatt.connect).toHaveBeenCalledTimes(2);
+	});
+
+	it('awaits startNotifications and fails the connect if it never succeeds', async () => {
+		const service = new FakeService();
+		const state = await service.getCharacteristic(GAN_TIMER_STATE_CHARACTERISTIC);
+		state.startNotifications.mockRejectedValue(new Error('GATT operation failed'));
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		await expect(connectGanTimer(options)).rejects.toBeInstanceOf(GanTimerConnectionError);
+	});
+
+	it('tears down the GATT link when setup fails, so the timer does not stay connected', async () => {
+		// This is the reported symptom: the timer shows connected while the app does not.
+		const service = new FakeService({characteristics: []});
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		await expect(connectGanTimer(options)).rejects.toBeInstanceOf(GanTimerConnectionError);
+		expect(device.gatt.disconnect).toHaveBeenCalled();
+		expect(device.gatt.connected).toBe(false);
+	});
+
+	it('emits decoded events from state notifications', async () => {
+		const service = new FakeService();
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+		const events: number[] = [];
+		conn.events$.subscribe((e) => events.push(e.state));
+
+		const state = await service.getCharacteristic(GAN_TIMER_STATE_CHARACTERISTIC);
+		state.emit(buildPacket(GanTimerState.HANDS_ON));
+		state.emit(buildPacket(GanTimerState.RUNNING));
+
+		expect(events).toEqual([GanTimerState.HANDS_ON, GanTimerState.RUNNING]);
+	});
+
+	it('drops an invalid packet but keeps the stream alive', async () => {
+		// A single corrupt notification must not permanently kill the timer.
+		const service = new FakeService();
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+		const events: number[] = [];
+		const errors: unknown[] = [];
+		conn.events$.subscribe({next: (e) => events.push(e.state), error: (e) => errors.push(e)});
+
+		const state = await service.getCharacteristic(GAN_TIMER_STATE_CHARACTERISTIC);
+		state.emit(new DataView(new Uint8Array([0x00, 0x01, 0x02]).buffer));
+		state.emit(buildPacket(GanTimerState.RUNNING));
+
+		expect(errors).toEqual([]);
+		expect(events).toEqual([GanTimerState.RUNNING]);
+	});
+
+	it('emits DISCONNECT when the device drops the link', async () => {
+		const device = new FakeDevice();
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+		const events: number[] = [];
+		conn.events$.subscribe((e) => events.push(e.state));
+
+		device.emit('gattserverdisconnected');
+
+		expect(events).toEqual([GanTimerState.DISCONNECT]);
+	});
+
+	it('emits DISCONNECT exactly once when disconnect races with the hardware event', async () => {
+		const device = new FakeDevice();
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+		const events: number[] = [];
+		conn.events$.subscribe((e) => events.push(e.state));
+
+		await conn.disconnect();
+		device.emit('gattserverdisconnected');
+		await conn.disconnect();
+
+		expect(events).toEqual([GanTimerState.DISCONNECT]);
+	});
+
+	it('reads recorded times when the time characteristic is present', async () => {
+		const service = new FakeService();
+		const time = await service.getCharacteristic(GAN_TIMER_TIME_CHARACTERISTIC);
+		const bytes = new Uint8Array(16);
+		bytes.set([0, 12, 0x34, 0x01], 0); // 0:12.308
+		time.readValue.mockResolvedValue(new DataView(bytes.buffer));
+
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+		const times = await conn.getRecordedTimes();
+
+		expect(times.displayTime.asTimestamp).toBe(12308);
+		expect(times.previousTimes).toHaveLength(3);
+	});
+
+	it('surfaces a cancelled device chooser as a cancellation, not a failure', async () => {
+		const abort = new Error('User cancelled the requestDevice() chooser.');
+		abort.name = 'NotFoundError';
+		mockBluetooth(new FakeDevice(), jest.fn().mockRejectedValue(abort));
+
+		await expect(connectGanTimer(options)).rejects.toMatchObject({cancelled: true});
+	});
+
+	it('reports a missing Web Bluetooth implementation clearly', async () => {
+		setNavigator({});
+
+		await expect(connectGanTimer(options)).rejects.toBeInstanceOf(GanTimerConnectionError);
+	});
+});

--- a/client/components/timer/time-display/gan-timer/connect.ts
+++ b/client/components/timer/time-display/gan-timer/connect.ts
@@ -1,0 +1,318 @@
+import {
+	buildTimerEvent,
+	GanTimerEvent,
+	GanTimerRecordedTimes,
+	GanTimerState,
+	hexdump,
+	isValidEventData,
+	makeTimeFromRaw,
+	normalizeUuid,
+} from '@/components/timer/time-display/gan-timer/protocol';
+import {Observable, Subject} from 'rxjs';
+
+// GAN Smart Timer bluetooth service and characteristic UUIDs
+export const GAN_TIMER_SERVICE = '0000fff0-0000-1000-8000-00805f9b34fb';
+export const GAN_TIMER_TIME_CHARACTERISTIC = '0000fff2-0000-1000-8000-00805f9b34fb';
+export const GAN_TIMER_STATE_CHARACTERISTIC = '0000fff5-0000-1000-8000-00805f9b34fb';
+
+// GAN timers report themselves under a handful of casings depending on the OS.
+// macOS in particular has been seen advertising the lowercase variant.
+const NAME_PREFIXES = ['GAN', 'Gan', 'gan'];
+
+const DEFAULT_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 250;
+
+export interface GanTimerConnectOptions {
+	/** Attempts made for each flaky GATT operation. Exposed for tests. */
+	retries?: number;
+	/** Delay between attempts. Exposed for tests. */
+	retryDelayMs?: number;
+}
+
+/**
+ * Error raised when we cannot establish a usable connection to the timer.
+ *
+ * `cancelled` marks the case where the user simply dismissed the browser's
+ * device chooser, which should not be reported to them as a failure.
+ */
+export class GanTimerConnectionError extends Error {
+	readonly cancelled: boolean;
+	readonly cause?: unknown;
+
+	constructor(message: string, {cancelled = false, cause}: {cancelled?: boolean; cause?: unknown} = {}) {
+		super(message);
+		this.name = 'GanTimerConnectionError';
+		this.cancelled = cancelled;
+		this.cause = cause;
+	}
+}
+
+/** Connection object representing the timer connection API and state */
+export interface GanTimerConnection {
+	/** Stream of timer state events */
+	events$: Observable<GanTimerEvent>;
+	/** Retrieve the last times recorded by the timer */
+	getRecordedTimes(): Promise<GanTimerRecordedTimes>;
+	/** Disconnect from the timer */
+	disconnect(): Promise<void>;
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Retry a flaky GATT operation.
+ *
+ * Chrome's Web Bluetooth stack — especially on macOS, where CoreBluetooth caches
+ * GATT attributes — regularly fails the first service or characteristic lookup
+ * right after connecting, then succeeds on a second attempt.
+ */
+async function withRetry<T>(operation: () => Promise<T>, retries: number, retryDelayMs: number): Promise<T> {
+	let lastError: unknown;
+
+	for (let attempt = 0; attempt < retries; attempt++) {
+		try {
+			return await operation();
+		} catch (err) {
+			lastError = err;
+			if (attempt < retries - 1) {
+				await delay(retryDelayMs);
+			}
+		}
+	}
+
+	throw lastError;
+}
+
+/** True when the rejection means "the user closed the device chooser" */
+function isChooserCancellation(err: unknown): boolean {
+	const name = (err as Error)?.name;
+	const message = (err as Error)?.message ?? '';
+	return (
+		name === 'AbortError' ||
+		(name === 'NotFoundError' && /cancell?ed|chooser|user/i.test(message))
+	);
+}
+
+async function requestTimerDevice(): Promise<BluetoothDevice> {
+	if (typeof navigator === 'undefined' || !navigator.bluetooth) {
+		throw new GanTimerConnectionError(
+			'Web Bluetooth is not available in this browser. Try Chrome on desktop or Android, or Bluefy on iOS.'
+		);
+	}
+
+	try {
+		return await navigator.bluetooth.requestDevice({
+			filters: [
+				...NAME_PREFIXES.map((namePrefix) => ({namePrefix})),
+				// Match on the advertised service too. Not every timer presents a
+				// name the browser will surface, and without this they never show
+				// up in the chooser at all.
+				{services: [GAN_TIMER_SERVICE]},
+			],
+			optionalServices: [GAN_TIMER_SERVICE],
+		});
+	} catch (err) {
+		if (isChooserCancellation(err)) {
+			throw new GanTimerConnectionError('Timer selection was cancelled.', {
+				cancelled: true,
+				cause: err,
+			});
+		}
+		throw new GanTimerConnectionError(
+			'Could not open the Bluetooth device chooser. Make sure Bluetooth is turned on and this page is served over HTTPS.',
+			{cause: err}
+		);
+	}
+}
+
+/**
+ * Locate the timer service.
+ *
+ * Looking the service up by UUID is the fast path, but it is also the operation
+ * that fails most often in the wild, so fall back to enumerating every primary
+ * service and matching the UUID ourselves.
+ */
+async function resolveTimerService(
+	server: BluetoothRemoteGATTServer,
+	{retries, retryDelayMs}: Required<GanTimerConnectOptions>
+): Promise<BluetoothRemoteGATTService> {
+	try {
+		return await withRetry(() => server.getPrimaryService(GAN_TIMER_SERVICE), retries, retryDelayMs);
+	} catch (lookupError) {
+		let services: BluetoothRemoteGATTService[];
+		try {
+			services = await withRetry(() => server.getPrimaryServices(), retries, retryDelayMs);
+		} catch {
+			throw new GanTimerConnectionError(
+				'Connected to the timer, but its Bluetooth services could not be read. Turn the timer off and on, then try again.',
+				{cause: lookupError}
+			);
+		}
+
+		const service = services.find((s) => normalizeUuid(s.uuid) === GAN_TIMER_SERVICE);
+		if (!service) {
+			const found = services.map((s) => normalizeUuid(s.uuid)).join(', ') || 'none';
+			throw new GanTimerConnectionError(
+				`This device does not expose the GAN Smart Timer service. Services found: ${found}.`,
+				{cause: lookupError}
+			);
+		}
+
+		return service;
+	}
+}
+
+/**
+ * Connect to a GAN Smart Timer over Web Bluetooth.
+ *
+ * Written against the same protocol as `gan-web-bluetooth`, but deliberately
+ * more forgiving about how the device presents itself: the time characteristic
+ * is optional, service discovery is retried, and a malformed notification is
+ * dropped rather than tearing down the event stream.
+ */
+export async function connectGanTimer(
+	options: GanTimerConnectOptions = {}
+): Promise<GanTimerConnection> {
+	const settings: Required<GanTimerConnectOptions> = {
+		retries: options.retries ?? DEFAULT_RETRIES,
+		retryDelayMs: options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS,
+	};
+
+	const device = await requestTimerDevice();
+
+	if (!device.gatt) {
+		throw new GanTimerConnectionError('The selected device does not support GATT connections.');
+	}
+	const gatt = device.gatt;
+
+	let server: BluetoothRemoteGATTServer;
+	try {
+		server = await withRetry(() => gatt.connect(), settings.retries, settings.retryDelayMs);
+	} catch (err) {
+		throw new GanTimerConnectionError(
+			'Could not connect to the timer. Make sure it is switched on and not already paired with another app or tab.',
+			{cause: err}
+		);
+	}
+
+	// From here on the device is connected, and will show itself as connected on
+	// its own display. Anything that goes wrong has to hang the link up again,
+	// otherwise the timer sits there looking connected while CubeDesk is not.
+	try {
+		const service = await resolveTimerService(server, settings);
+
+		const stateCharacteristic = await withRetry(
+			() => service.getCharacteristic(GAN_TIMER_STATE_CHARACTERISTIC),
+			settings.retries,
+			settings.retryDelayMs
+		).catch((err) => {
+			throw new GanTimerConnectionError(
+				'The timer did not expose its state characteristic, so CubeDesk cannot receive solve events from it.',
+				{cause: err}
+			);
+		});
+
+		// Only used by getRecordedTimes(). A timer that does not expose it is
+		// still perfectly usable, so never let this block the connection.
+		const timeCharacteristic = await service
+			.getCharacteristic(GAN_TIMER_TIME_CHARACTERISTIC)
+			.catch(() => null);
+
+		const eventSubject = new Subject<GanTimerEvent>();
+
+		const onStateChanged = (evt: Event) => {
+			const data = (evt.target as BluetoothRemoteGATTCharacteristic)?.value;
+			if (!isValidEventData(data)) {
+				// Log and move on. Erroring the stream here would permanently kill
+				// the timer over a single corrupt packet.
+				console.warn('[GanTimer] discarding invalid packet from timer:', hexdump(data));
+				return;
+			}
+
+			const event = buildTimerEvent(data as DataView);
+			if (event) {
+				eventSubject.next(event);
+			}
+		};
+
+		stateCharacteristic.addEventListener('characteristicvaluechanged', onStateChanged);
+
+		try {
+			await withRetry(
+				() => stateCharacteristic.startNotifications(),
+				settings.retries,
+				settings.retryDelayMs
+			);
+		} catch (err) {
+			stateCharacteristic.removeEventListener('characteristicvaluechanged', onStateChanged);
+			throw new GanTimerConnectionError(
+				'Connected to the timer, but CubeDesk could not subscribe to its updates. Turn the timer off and on, then try again.',
+				{cause: err}
+			);
+		}
+
+		let closed = false;
+		const teardown = async () => {
+			if (closed) {
+				return;
+			}
+			closed = true;
+
+			device.removeEventListener('gattserverdisconnected', onGattDisconnected);
+			stateCharacteristic.removeEventListener('characteristicvaluechanged', onStateChanged);
+
+			// Announce the disconnect synchronously so the UI reacts immediately,
+			// then let the GATT teardown finish in the background.
+			eventSubject.next({state: GanTimerState.DISCONNECT});
+			eventSubject.complete();
+
+			if (gatt.connected) {
+				await stateCharacteristic.stopNotifications().catch(() => undefined);
+				gatt.disconnect();
+			}
+		};
+
+		function onGattDisconnected() {
+			void teardown();
+		}
+
+		device.addEventListener('gattserverdisconnected', onGattDisconnected);
+
+		return {
+			events$: eventSubject.asObservable(),
+			disconnect: teardown,
+			getRecordedTimes: async (): Promise<GanTimerRecordedTimes> => {
+				if (!timeCharacteristic) {
+					throw new GanTimerConnectionError(
+						'This timer does not expose its recorded times.'
+					);
+				}
+
+				const data = await timeCharacteristic.readValue();
+				if (!data || data.byteLength < 16) {
+					throw new GanTimerConnectionError(
+						'Invalid time value received from the timer.'
+					);
+				}
+
+				return {
+					displayTime: makeTimeFromRaw(data, 0),
+					previousTimes: [
+						makeTimeFromRaw(data, 4),
+						makeTimeFromRaw(data, 8),
+						makeTimeFromRaw(data, 12),
+					],
+				};
+			},
+		};
+	} catch (err) {
+		if (gatt.connected) {
+			gatt.disconnect();
+		}
+		throw err instanceof GanTimerConnectionError
+			? err
+			: new GanTimerConnectionError('Could not set up the timer connection.', {cause: err});
+	}
+}

--- a/client/components/timer/time-display/gan-timer/protocol.test.ts
+++ b/client/components/timer/time-display/gan-timer/protocol.test.ts
@@ -1,0 +1,121 @@
+import {
+	buildTimerEvent,
+	crc16ccit,
+	GanTimerState,
+	isValidEventData,
+	makeTimeFromRaw,
+	normalizeUuid,
+} from '@/components/timer/time-display/gan-timer/protocol';
+
+/**
+ * Build a well-formed GAN Smart Timer state packet.
+ *
+ * Layout: [0]=0xFE magic, [1]=length, [2]=?, [3]=state, [4..]=payload, last 2 bytes=CRC16.
+ * The CRC is computed over the packet starting at offset 2, excluding the trailing CRC.
+ */
+function buildPacket(state: number, payload: number[] = []): DataView {
+	const body = [0xfe, 0x00, 0x00, state, ...payload];
+	const crcInput = new Uint8Array(body.slice(2));
+	const crc = crc16ccit(crcInput.buffer);
+
+	const bytes = new Uint8Array([...body, crc & 0xff, (crc >> 8) & 0xff]);
+	return new DataView(bytes.buffer);
+}
+
+describe('gan timer protocol', () => {
+	describe('isValidEventData', () => {
+		it('accepts a packet with the right magic byte and CRC', () => {
+			expect(isValidEventData(buildPacket(GanTimerState.IDLE))).toBe(true);
+		});
+
+		it('rejects a packet with a bad magic byte', () => {
+			const packet = buildPacket(GanTimerState.IDLE);
+			packet.setUint8(0, 0x00);
+			expect(isValidEventData(packet)).toBe(false);
+		});
+
+		it('rejects a packet with a corrupted CRC', () => {
+			const packet = buildPacket(GanTimerState.IDLE);
+			packet.setUint8(packet.byteLength - 1, 0xff);
+			packet.setUint8(packet.byteLength - 2, 0xff);
+			expect(isValidEventData(packet)).toBe(false);
+		});
+
+		it('rejects empty and missing data instead of throwing', () => {
+			expect(isValidEventData(new DataView(new ArrayBuffer(0)))).toBe(false);
+			expect(isValidEventData(null)).toBe(false);
+			expect(isValidEventData(undefined)).toBe(false);
+		});
+
+		it('validates a packet backed by a buffer with a non-zero byte offset', () => {
+			// Some Web Bluetooth implementations hand back a DataView into a
+			// larger pooled buffer. CRC must be computed over the view, not the buffer.
+			const source = buildPacket(GanTimerState.RUNNING);
+			const padded = new Uint8Array(4 + source.byteLength);
+			padded.set(new Uint8Array(source.buffer), 4);
+
+			const offsetView = new DataView(padded.buffer, 4, source.byteLength);
+			expect(isValidEventData(offsetView)).toBe(true);
+		});
+	});
+
+	describe('buildTimerEvent', () => {
+		it.each([
+			['HANDS_ON', GanTimerState.HANDS_ON],
+			['HANDS_OFF', GanTimerState.HANDS_OFF],
+			['GET_SET', GanTimerState.GET_SET],
+			['RUNNING', GanTimerState.RUNNING],
+			['IDLE', GanTimerState.IDLE],
+			['FINISHED', GanTimerState.FINISHED],
+		])('decodes the %s state', (_name, state) => {
+			expect(buildTimerEvent(buildPacket(state))).toEqual({state});
+		});
+
+		it('decodes the recorded time on a STOPPED event', () => {
+			// 1 minute, 23 seconds, 456 milliseconds
+			const packet = buildPacket(GanTimerState.STOPPED, [1, 23, 456 & 0xff, 456 >> 8]);
+			const event = buildTimerEvent(packet);
+
+			expect(event?.state).toBe(GanTimerState.STOPPED);
+			expect(event?.recordedTime?.asTimestamp).toBe(83456);
+			expect(event?.recordedTime?.toString()).toBe('1:23.456');
+		});
+
+		it('drops packets carrying an unknown state rather than emitting garbage', () => {
+			expect(buildTimerEvent(buildPacket(42))).toBeNull();
+		});
+
+		it('drops a STOPPED packet that is too short to hold a time', () => {
+			expect(buildTimerEvent(buildPacket(GanTimerState.STOPPED))).toBeNull();
+		});
+	});
+
+	describe('makeTimeFromRaw', () => {
+		it('reads minutes, seconds and little-endian milliseconds', () => {
+			const bytes = new Uint8Array([2, 5, 7 & 0xff, 7 >> 8]);
+			const time = makeTimeFromRaw(new DataView(bytes.buffer), 0);
+
+			expect(time.minutes).toBe(2);
+			expect(time.seconds).toBe(5);
+			expect(time.milliseconds).toBe(7);
+			expect(time.asTimestamp).toBe(125007);
+			expect(time.toString()).toBe('2:05.007');
+		});
+	});
+
+	describe('normalizeUuid', () => {
+		it('expands a 16 bit UUID to its full 128 bit form', () => {
+			expect(normalizeUuid('fff0')).toBe('0000fff0-0000-1000-8000-00805f9b34fb');
+		});
+
+		it('lowercases a full UUID so comparisons are case insensitive', () => {
+			expect(normalizeUuid('0000FFF0-0000-1000-8000-00805F9B34FB')).toBe(
+				'0000fff0-0000-1000-8000-00805f9b34fb'
+			);
+		});
+
+		it('accepts a numeric 16 bit UUID as reported by some browsers', () => {
+			expect(normalizeUuid(0xfff0)).toBe('0000fff0-0000-1000-8000-00805f9b34fb');
+		});
+	});
+});

--- a/client/components/timer/time-display/gan-timer/protocol.ts
+++ b/client/components/timer/time-display/gan-timer/protocol.ts
@@ -1,0 +1,180 @@
+/**
+ * Wire protocol for the GAN Smart Timer.
+ *
+ * Kept free of any Web Bluetooth types so it can be unit tested directly.
+ * Credits to Andy Fedotov (https://github.com/afedotov/gan-web-bluetooth), whose
+ * reverse engineering of the protocol this is based on.
+ */
+
+/**
+ * GAN Smart Timer events/states.
+ *
+ * Values match the byte the timer puts at offset 3 of a state packet, and are
+ * kept identical to the `gan-web-bluetooth` enum this driver replaced.
+ */
+export enum GanTimerState {
+	/** Fired when timer is disconnected from bluetooth */
+	DISCONNECT = 0,
+	/** Grace delay is expired and timer is ready to start */
+	GET_SET = 1,
+	/** Hands removed from the timer before grace delay expired */
+	HANDS_OFF = 2,
+	/** Timer is running */
+	RUNNING = 3,
+	/** Timer is stopped, this event includes recorded time */
+	STOPPED = 4,
+	/** Timer is reset and idle */
+	IDLE = 5,
+	/** Hands are placed on the timer */
+	HANDS_ON = 6,
+	/** Timer moves to this state immediately after STOPPED */
+	FINISHED = 7,
+}
+
+const KNOWN_STATES = new Set<number>([
+	GanTimerState.DISCONNECT,
+	GanTimerState.GET_SET,
+	GanTimerState.HANDS_OFF,
+	GanTimerState.RUNNING,
+	GanTimerState.STOPPED,
+	GanTimerState.IDLE,
+	GanTimerState.HANDS_ON,
+	GanTimerState.FINISHED,
+]);
+
+/** Representation of a time value */
+export interface GanTimerTime {
+	readonly minutes: number;
+	readonly seconds: number;
+	readonly milliseconds: number;
+	readonly asTimestamp: number;
+	toString(): string;
+}
+
+/** Timer state event */
+export interface GanTimerEvent {
+	/** Current timer state */
+	state: GanTimerState;
+	/** Recorded time value, only present on a STOPPED event */
+	recordedTime?: GanTimerTime;
+}
+
+/** Representation of the time values recorded in the timer's memory */
+export interface GanTimerRecordedTimes {
+	displayTime: GanTimerTime;
+	previousTimes: [GanTimerTime, GanTimerTime, GanTimerTime];
+}
+
+export function makeTime(min: number, sec: number, msec: number): GanTimerTime {
+	return {
+		minutes: min,
+		seconds: sec,
+		milliseconds: msec,
+		asTimestamp: 60000 * min + 1000 * sec + msec,
+		toString: () =>
+			`${min.toString(10)}:${sec.toString(10).padStart(2, '0')}.${msec
+				.toString(10)
+				.padStart(3, '0')}`,
+	};
+}
+
+export function makeTimeFromRaw(data: DataView, offset: number): GanTimerTime {
+	return makeTime(data.getUint8(offset), data.getUint8(offset + 1), data.getUint16(offset + 2, true));
+}
+
+export function makeTimeFromTimestamp(timestamp: number): GanTimerTime {
+	return makeTime(
+		Math.trunc(timestamp / 60000),
+		Math.trunc((timestamp % 60000) / 1000),
+		Math.trunc(timestamp % 1000)
+	);
+}
+
+/** Calculate ArrayBuffer checksum using a CRC-16/CCITT-FALSE variation */
+export function crc16ccit(buff: ArrayBuffer): number {
+	const dataView = new DataView(buff);
+	let crc = 0xffff;
+	for (let i = 0; i < dataView.byteLength; ++i) {
+		crc ^= dataView.getUint8(i) << 8;
+		for (let j = 0; j < 8; ++j) {
+			crc = (crc & 0x8000) > 0 ? (crc << 1) ^ 0x1021 : crc << 1;
+		}
+	}
+	return crc & 0xffff;
+}
+
+/** Ensure a received timer packet has valid data: check the magic byte and CRC */
+export function isValidEventData(data: DataView | null | undefined): boolean {
+	try {
+		if (!data || data.byteLength < 6 || data.getUint8(0) !== 0xfe) {
+			return false;
+		}
+
+		const eventCRC = data.getUint16(data.byteLength - 2, true);
+		// Slice relative to the view, not the backing buffer, since some browsers
+		// hand back a DataView into a larger pooled ArrayBuffer.
+		const payload = new Uint8Array(data.buffer, data.byteOffset + 2, data.byteLength - 4);
+		const calculatedCRC = crc16ccit(payload.slice().buffer);
+
+		return eventCRC === calculatedCRC;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Build an event from a raw state packet.
+ *
+ * Returns null for anything we can't confidently decode, so a single odd packet
+ * gets dropped rather than tearing down the whole connection.
+ */
+export function buildTimerEvent(data: DataView): GanTimerEvent | null {
+	try {
+		const state = data.getUint8(3);
+		if (!KNOWN_STATES.has(state)) {
+			return null;
+		}
+
+		if (state === GanTimerState.STOPPED) {
+			// state byte + 4 time bytes + 2 CRC bytes must all fit
+			if (data.byteLength < 10) {
+				return null;
+			}
+			return {state, recordedTime: makeTimeFromRaw(data, 4)};
+		}
+
+		return {state};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Expand a UUID to its lowercase 128 bit form so that service and characteristic
+ * UUIDs can be compared regardless of how the browser reported them.
+ */
+export function normalizeUuid(uuid: string | number): string {
+	if (typeof uuid === 'number') {
+		return `0000${uuid.toString(16).padStart(4, '0')}-0000-1000-8000-00805f9b34fb`;
+	}
+
+	const trimmed = uuid.trim().toLowerCase();
+	if (/^(0x)?[0-9a-f]{1,4}$/.test(trimmed)) {
+		return `0000${trimmed.replace(/^0x/, '').padStart(4, '0')}-0000-1000-8000-00805f9b34fb`;
+	}
+
+	return trimmed;
+}
+
+/** Render a DataView as a hex string, for logging undecodable packets */
+export function hexdump(data: DataView | null | undefined): string {
+	if (!data) {
+		return '';
+	}
+
+	const bytes: string[] = [];
+	for (let i = 0; i < data.byteLength; i++) {
+		bytes.push(data.getUint8(i).toString(16).padStart(2, '0'));
+	}
+	return bytes.join(' ');
+}


### PR DESCRIPTION
Fixes #190

gan-web-bluetooth required the unused fff2 time characteristic before completing setup, had no retry on flaky GATT lookups, and connect() had no error handling — so a failed handshake left the timer showing "connected" on its own display with nothing visible in cubeDesk.

Replaces the library call with an in-repo driver that only requires the fff5 state characteristic, retries service/characteristic discovery, tears down the GATT link on setup failure, and surfaces a real error message instead of failing silently.
