### PR TITLE
Fix/gan cube connection

### DIFF
--- a/client/@types/client.d.ts
+++ b/client/@types/client.d.ts
@@ -40,6 +40,11 @@ interface BluetoothDevice extends EventTarget {
 	id: string;
 	name?: string;
 	gatt?: BluetoothRemoteGATTServer;
+	/**
+	 * Behind chrome://flags/#enable-experimental-web-platform-features on most
+	 * installs, hence optional — GAN's automatic MAC address lookup needs it.
+	 */
+	watchAdvertisements?(options?: {signal?: AbortSignal}): Promise<void>;
 }
 
 interface Bluetooth {
@@ -47,6 +52,11 @@ interface Bluetooth {
 	requestDevice(options?: {
 		filters?: BluetoothRequestDeviceFilter[];
 		optionalServices?: string[];
+		/**
+		 * Company identifiers whose manufacturer-specific advertisement data
+		 * should be exposed. Chrome strips data for any identifier not listed.
+		 */
+		optionalManufacturerData?: number[];
 		acceptAllDevices?: boolean;
 	}): Promise<BluetoothDevice>;
 }

--- a/client/@types/client.d.ts
+++ b/client/@types/client.d.ts
@@ -13,10 +13,27 @@ interface BluetoothRequestDeviceFilter {
 	namePrefix?: string;
 }
 
+interface BluetoothRemoteGATTCharacteristic extends EventTarget {
+	uuid: string;
+	value?: DataView;
+	readValue(): Promise<DataView>;
+	writeValue(value: BufferSource): Promise<void>;
+	startNotifications(): Promise<BluetoothRemoteGATTCharacteristic>;
+	stopNotifications(): Promise<BluetoothRemoteGATTCharacteristic>;
+}
+
+interface BluetoothRemoteGATTService {
+	uuid: string;
+	getCharacteristic(characteristic: string): Promise<BluetoothRemoteGATTCharacteristic>;
+	getCharacteristics(characteristic?: string): Promise<BluetoothRemoteGATTCharacteristic[]>;
+}
+
 interface BluetoothRemoteGATTServer {
 	connected: boolean;
 	connect(): Promise<BluetoothRemoteGATTServer>;
 	disconnect(): void;
+	getPrimaryService(service: string): Promise<BluetoothRemoteGATTService>;
+	getPrimaryServices(service?: string): Promise<BluetoothRemoteGATTService[]>;
 }
 
 interface BluetoothDevice extends EventTarget {

--- a/client/components/timer/common/GanTimerErrorMessage.tsx
+++ b/client/components/timer/common/GanTimerErrorMessage.tsx
@@ -1,0 +1,35 @@
+import ModalHeader from '@/components/common/modal/ModalHeader';
+import React from 'react';
+
+interface Props {
+	message: string;
+}
+
+export default function GanTimerErrorMessage({message}: Props) {
+	const title = <span style={{color: 'rgb(var(--error-color))'}}>Could not connect to timer</span>;
+	const description = <span style={{color: 'rgb(var(--warning-color))'}}>{message}</span>;
+
+	return (
+		<>
+			<ModalHeader title={title} description={description} />
+			<p>
+				Things worth trying:
+				<ul style={{listStyle: 'disc', margin: '1em', paddingLeft: '1em'}}>
+					<li>Turn the timer off and back on, then connect again.</li>
+					<li>
+						Close any other tab or app that is connected to the timer. A GAN Smart Timer
+						only talks to one at a time.
+					</li>
+					<li>
+						Remove the timer from your operating system&apos;s Bluetooth settings if you
+						paired it there, then retry. It should be paired from the browser, not the OS.
+					</li>
+					<li>
+						On Chrome, visit <code>chrome://bluetooth-internals</code> to confirm the
+						timer is advertising.
+					</li>
+				</ul>
+			</p>
+		</>
+	);
+}

--- a/client/components/timer/common/SmartCubeErrorMessage.tsx
+++ b/client/components/timer/common/SmartCubeErrorMessage.tsx
@@ -1,0 +1,36 @@
+import ModalHeader from '@/components/common/modal/ModalHeader';
+import React from 'react';
+
+interface Props {
+	message: string;
+}
+
+export default function SmartCubeErrorMessage({message}: Props) {
+	const title = <span style={{color: 'rgb(var(--error-color))'}}>Could not connect to cube</span>;
+	const description = <span style={{color: 'rgb(var(--warning-color))'}}>{message}</span>;
+
+	return (
+		<>
+			<ModalHeader title={title} description={description} />
+			<p>
+				Things worth trying:
+				<ul style={{listStyle: 'disc', margin: '1em', paddingLeft: '1em'}}>
+					<li>Give the cube a turn to wake it up, then connect again.</li>
+					<li>
+						Close any other tab or app that is connected to the cube. A smart cube only
+						talks to one at a time.
+					</li>
+					<li>
+						Remove the cube from your operating system&apos;s Bluetooth settings if you
+						paired it there, then retry. It should be paired from the browser, not the
+						OS.
+					</li>
+					<li>
+						On Chrome, visit <code>chrome://bluetooth-internals</code> to confirm the
+						cube is advertising.
+					</li>
+				</ul>
+			</p>
+		</>
+	);
+}

--- a/client/components/timer/smart-cube/SmartCube.tsx
+++ b/client/components/timer/smart-cube/SmartCube.tsx
@@ -3,16 +3,17 @@ import Button from '@/components/common/Button';
 import Emblem from '@/components/common/Emblem';
 import Dropdown from '@/components/common/inputs/dropdown/Dropdown';
 import BluetoothErrorMessage from '@/components/timer/common/BluetoothErrorMessage';
+import SmartCubeErrorMessage from '@/components/timer/common/SmartCubeErrorMessage';
 import {endTimer, startTimer} from '@/components/timer/helpers/events';
 import {setTimerParams} from '@/components/timer/helpers/params';
 import Battery from '@/components/timer/smart-cube/battery/Battery';
 import Connect from '@/components/timer/smart-cube/bluetooth/connect';
+import {SmartCubeConnectionError} from '@/components/timer/smart-cube/bluetooth/errors';
 import ManageSmartCubes from '@/components/timer/smart-cube/manage-smart-cubes/ManageSmartCubes';
 import {preflightChecks} from '@/components/timer/smart-cube/preflight';
 import {RubiksCube} from '@/components/timer/smart-cube/visual/core/RubiksCube';
 import {useTimerContext} from '@/components/timer/Timer';
 import {useSettings} from '@/util/hooks/useSettings';
-import {toastError} from '@/util/toast';
 import Cube from 'cubejs';
 import {Bluetooth, DotsThree} from 'phosphor-react';
 import React, {ReactNode, useEffect, useRef, useState} from 'react';
@@ -58,7 +59,7 @@ export default function SmartCube() {
 				turnInterval.current = null;
 			}
 
-			connect.current.disconnect();
+			void connect.current.disconnect();
 		};
 	}, []);
 
@@ -232,19 +233,36 @@ export default function SmartCube() {
 		try {
 			const bluetoothAvailable =
 				!!navigator.bluetooth && (await navigator.bluetooth.getAvailability());
-			if (bluetoothAvailable) {
-				connect.current.connect();
-			} else {
+			if (!bluetoothAvailable) {
 				dispatch(openModal(<BluetoothErrorMessage />));
+				return;
 			}
-		} catch (e) {
-			toastError('Web Bluetooth API error' + (e ? `: ${e}` : ''));
-			// chrome://flags/#enable-experimental-web-platform-features
+
+			await connect.current.connect();
+		} catch (err) {
+			// Anything that goes wrong has to clear the connecting flag, otherwise
+			// the button sits on a disabled "Connecting..." until the page reloads.
+			await connect.current.disconnect();
+			setTimerParams({
+				smartCanStart: false,
+				smartCubeConnected: false,
+				smartCubeConnecting: false,
+			});
+
+			// The user just closed the device chooser; nothing to report.
+			if (err instanceof SmartCubeConnectionError && err.cancelled) {
+				return;
+			}
+
+			console.error('[SmartCube] connection failed', err);
+			const message =
+				err instanceof Error ? err.message : 'An unknown error occurred while connecting.';
+			dispatch(openModal(<SmartCubeErrorMessage message={message} />));
 		}
 	}
 
 	function disconnectBluetooth() {
-		connect.current.disconnect();
+		void connect.current.disconnect();
 		setTimerParams({
 			smartCanStart: false,
 			smartCubeConnected: false,

--- a/client/components/timer/smart-cube/bluetooth/connect.ts
+++ b/client/components/timer/smart-cube/bluetooth/connect.ts
@@ -1,33 +1,55 @@
+import {isChooserCancellation, SmartCubeConnectionError} from '@/components/timer/smart-cube/bluetooth/errors';
 import GAN from '@/components/timer/smart-cube/bluetooth/gan';
+import {
+	GAN_COMPANY_IDENTIFIERS,
+	GAN_CUBE_NAME_PREFIXES,
+	GAN_CUBE_SERVICES,
+	isGanCubeName,
+} from '@/components/timer/smart-cube/bluetooth/gan-cube/connect';
 import Giiker from '@/components/timer/smart-cube/bluetooth/giiker';
 import Particula from '@/components/timer/smart-cube/bluetooth/particula';
 import SmartCube from '@/components/timer/smart-cube/bluetooth/smart_cube';
 
+/** Any cube driver we can hand a chosen device to. */
+interface CubeDriver {
+	init(): Promise<void>;
+	disconnect?(): Promise<void>;
+}
+
 export default class Connect extends SmartCube {
 	device: BluetoothDevice | null = null;
+	cube: CubeDriver | null = null;
 
-	connect = () => {
-		if (!window.navigator || !window.navigator.bluetooth) {
-			throw new Error();
+	connect = async (): Promise<void> => {
+		if (typeof navigator === 'undefined' || !navigator.bluetooth) {
+			throw new SmartCubeConnectionError(
+				'Web Bluetooth is not available in this browser. Try Chrome on desktop or Android, or Bluefy on iOS.'
+			);
 		}
 
-		window.navigator.bluetooth
-			.requestDevice({
+		let device: BluetoothDevice;
+		try {
+			device = await navigator.bluetooth.requestDevice({
 				filters: [
 					{namePrefix: 'Gi'},
 					{namePrefix: 'Mi Smart Magic Cube'},
-					{namePrefix: 'GAN'},
-					{namePrefix: 'Gan'},
-					{namePrefix: 'gan'},
 					{namePrefix: 'GoCube'},
 					{namePrefix: 'Rubiks'},
+
+					// GAN cubes ship under several brands, in inconsistent casing.
+					...GAN_CUBE_NAME_PREFIXES.map((namePrefix) => ({namePrefix})),
+					{namePrefix: 'Gan'},
+					{namePrefix: 'gan'},
 
 					// Giiker
 					{services: ['0000aadb-0000-1000-8000-00805f9b34fb']},
 					{services: ['0000aaaa-0000-1000-8000-00805f9b34fb']},
 					{services: ['0000fe95-0000-1000-8000-00805f9b34fb']},
 
-					// Gan
+					// Match GAN cubes on their advertised service too — not every
+					// one presents a name the browser will surface, and without
+					// this they never show up in the chooser at all.
+					...GAN_CUBE_SERVICES.map((service) => ({services: [service]})),
 					{services: ['0000fff0-0000-1000-8000-00805f9b34fb']},
 					{services: ['00001805-0000-1000-8000-00805f9b34fb']},
 				],
@@ -37,7 +59,6 @@ export default class Connect extends SmartCube {
 					'9fa480e0-4967-4542-9390-d343dc5d04ae',
 					'00001805-0000-1000-8000-00805f9b34fb',
 					'd0611e78-bbb4-4591-a5f8-487910ae4366',
-					'6e400001-b5a3-f393-e0a9-e50e24dc4179',
 					'f95a48e6-a721-11e9-a2a3-022ae2dbcce4',
 
 					'battery_service',
@@ -45,48 +66,84 @@ export default class Connect extends SmartCube {
 					'device_information',
 					...Particula.opServices,
 
-					// GAN
+					// GAN. The three protocol generations plus the device
+					// information service the cubes report their hardware through.
+					...GAN_CUBE_SERVICES,
 					'0000fff0-0000-1000-8000-00805f9b34fb',
-					'0000fff5-0000-1000-8000-00805f9b34fb',
-					'0000fff7-0000-1000-8000-00805f9b34fb',
-					'0000fff2-0000-1000-8000-00805f9b34fb',
-					'0000fff3-0000-1000-8000-00805f9b34fb',
-					'0000180a-0000-1000-8000-00805f9b34fb',
 					'00002a23-0000-1000-8000-00805f9b34fb',
 					'00002a28-0000-1000-8000-00805f9b34fb',
-					'8653000a-43e6-47b7-9cb0-5fc21d4ae340',
-					'00000010-0000-fff7-fff6-fff5fff4fff0',
-
-					'00001805-0000-1000-8000-00805f9b34fb'
+					'00001805-0000-1000-8000-00805f9b34fb',
 				],
-			})
-			.then((device) => {
-				this.device = device;
-
-				this.alertConnecting();
-
-				const name = device.name ?? '';
-				if (name.startsWith('Gi') || name.startsWith('Mi Smart Magic Cube')) {
-					const cube = new Giiker(this.device);
-					cube.init();
-				} else if (name.toLowerCase().startsWith('gan')) {
-					const cube = new GAN(this.device);
-					cube.init();
-				} else if (name.startsWith('GoCube') || name.startsWith('Rubiks')) {
-					const cube = new Particula(this.device);
-					cube.init();
-				} else {
-					// HANDLE unsupported cube
-					return Promise.resolve();
-				}
+				// GAN encodes the cube's MAC address here, and it is dropped
+				// unless the company identifiers are declared at request time.
+				// Without it every GAN user is asked to type their MAC by hand.
+				optionalManufacturerData: GAN_COMPANY_IDENTIFIERS,
 			});
+		} catch (err) {
+			if (isChooserCancellation(err)) {
+				throw new SmartCubeConnectionError('Cube selection was cancelled.', {
+					cancelled: true,
+					cause: err,
+				});
+			}
+			throw new SmartCubeConnectionError(
+				'Could not open the Bluetooth device chooser. Make sure Bluetooth is turned on and this page is served over HTTPS.',
+				{cause: err}
+			);
+		}
+
+		this.device = device;
+		this.alertConnecting();
+
+		const name = device.name ?? '';
+		let cube: CubeDriver;
+		if (name.startsWith('Gi') || name.startsWith('Mi Smart Magic Cube')) {
+			cube = new Giiker(device);
+		} else if (isGanCubeName(name)) {
+			cube = new GAN(device);
+		} else if (name.startsWith('GoCube') || name.startsWith('Rubiks')) {
+			cube = new Particula(device);
+		} else {
+			// Previously this returned silently, which left the UI stuck on
+			// "Connecting..." with no way out short of a page reload.
+			this.device = null;
+			throw new SmartCubeConnectionError(
+				`CubeDesk does not know how to talk to "${name || 'that device'}". Supported cubes are GAN, GoCube, Rubik's Connected and Giiker.`
+			);
+		}
+
+		this.cube = cube;
+
+		try {
+			await cube.init();
+		} catch (err) {
+			// A half-finished init can leave a live GATT link behind, and a cube
+			// that thinks it is still connected will refuse the next attempt.
+			await this.disconnect();
+
+			throw err instanceof SmartCubeConnectionError
+				? err
+				: new SmartCubeConnectionError(
+						`Could not connect to the cube${err instanceof Error && err.message ? `: ${err.message}` : '.'}`,
+						{cause: err}
+				  );
+		}
 	};
 
-	disconnect = () => {
-		if (!this.device) {
-			return;
-		}
-		this.device.gatt?.disconnect();
+	/** Never rejects — callers tear down UI state regardless of how this goes. */
+	disconnect = async (): Promise<void> => {
+		const cube = this.cube;
+		const device = this.device;
+
+		this.cube = null;
 		this.device = null;
+
+		try {
+			await cube?.disconnect?.();
+		} catch (err) {
+			console.error('[SmartCube] error while disconnecting', err);
+		}
+
+		device?.gatt?.disconnect();
 	};
 }

--- a/client/components/timer/smart-cube/bluetooth/errors.ts
+++ b/client/components/timer/smart-cube/bluetooth/errors.ts
@@ -1,0 +1,24 @@
+/**
+ * Error raised when a smart cube cannot be connected.
+ *
+ * `cancelled` marks the cases where the user simply dismissed the browser's
+ * device chooser or a prompt, which should not be reported back as a failure.
+ */
+export class SmartCubeConnectionError extends Error {
+	readonly cancelled: boolean;
+	readonly cause?: unknown;
+
+	constructor(message: string, {cancelled = false, cause}: {cancelled?: boolean; cause?: unknown} = {}) {
+		super(message);
+		this.name = 'SmartCubeConnectionError';
+		this.cancelled = cancelled;
+		this.cause = cause;
+	}
+}
+
+/** True when a rejection means "the user closed the device chooser". */
+export function isChooserCancellation(err: unknown): boolean {
+	const name = (err as Error)?.name;
+	const message = (err as Error)?.message ?? '';
+	return name === 'AbortError' || (name === 'NotFoundError' && /cancell?ed|chooser|user/i.test(message));
+}

--- a/client/components/timer/smart-cube/bluetooth/gan-cube/connect.test.ts
+++ b/client/components/timer/smart-cube/bluetooth/gan-cube/connect.test.ts
@@ -1,0 +1,279 @@
+import {SmartCubeConnectionError} from '@/components/timer/smart-cube/bluetooth/errors';
+import {
+	connectGanCubeDevice,
+	createMacAddressProvider,
+	forgetStoredMacAddress,
+	GAN_COMPANY_IDENTIFIERS,
+	GanCubeConnectionError,
+	isGanCubeName,
+	normalizeMacAddress,
+	readStoredMacAddress,
+	storeMacAddress,
+} from '@/components/timer/smart-cube/bluetooth/gan-cube/connect';
+import {connectGanCube} from 'gan-web-bluetooth';
+
+jest.mock('gan-web-bluetooth', () => ({
+	connectGanCube: jest.fn(),
+}));
+
+const mockedConnectGanCube = connectGanCube as jest.MockedFunction<typeof connectGanCube>;
+
+/** Node exposes `navigator` as a non-writable accessor, so redefine it outright */
+function setNavigator(value: unknown) {
+	Object.defineProperty(global, 'navigator', {value, configurable: true, writable: true});
+}
+
+function setLocalStorage() {
+	const store = new Map<string, string>();
+	Object.defineProperty(global, 'window', {
+		configurable: true,
+		writable: true,
+		value: {
+			localStorage: {
+				getItem: (k: string) => store.get(k) ?? null,
+				setItem: (k: string, v: string) => void store.set(k, v),
+				removeItem: (k: string) => void store.delete(k),
+			},
+		},
+	});
+	return store;
+}
+
+function fakeDevice(overrides: Partial<BluetoothDevice> = {}): BluetoothDevice {
+	return {
+		id: 'device-id',
+		name: 'GAN-1a2b3c',
+		...overrides,
+	} as BluetoothDevice;
+}
+
+const fakeConnection = {deviceName: 'GAN356 i3', deviceMAC: 'AB:CD:EF:12:34:56'};
+
+describe('connectGanCubeDevice', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+		delete (global as any).navigator;
+		delete (global as any).window;
+	});
+
+	/**
+	 * The bug behind issue #185: the library opens its own device chooser, and a
+	 * second requestDevice() outside of a user gesture is rejected by Chrome, so
+	 * cubes bonded with the OS ("paired") but never connected to CubeDesk.
+	 */
+	it('gives the library the already-selected device instead of opening a second chooser', async () => {
+		const realRequestDevice = jest.fn().mockRejectedValue(
+			Object.assign(new Error('Must be handling a user gesture to show a permission request.'), {
+				name: 'SecurityError',
+			})
+		);
+		setNavigator({bluetooth: {requestDevice: realRequestDevice}});
+
+		const device = fakeDevice();
+		let deviceSeenByLibrary: BluetoothDevice | null = null;
+
+		mockedConnectGanCube.mockImplementation(async () => {
+			// Stand in for what the library does internally.
+			deviceSeenByLibrary = await navigator.bluetooth!.requestDevice({});
+			return fakeConnection as any;
+		});
+
+		await expect(connectGanCubeDevice(device)).resolves.toBe(fakeConnection);
+
+		expect(deviceSeenByLibrary).toBe(device);
+		expect(realRequestDevice).not.toHaveBeenCalled();
+	});
+
+	it('restores the real requestDevice once the library has taken the device', async () => {
+		const realRequestDevice = jest.fn();
+		const bluetooth = {requestDevice: realRequestDevice};
+		setNavigator({bluetooth});
+
+		mockedConnectGanCube.mockImplementation(async () => {
+			await navigator.bluetooth!.requestDevice({});
+			// A later call - anything else on the page - must reach the real chooser.
+			expect(navigator.bluetooth!.requestDevice).toBe(realRequestDevice);
+			return fakeConnection as any;
+		});
+
+		await connectGanCubeDevice(fakeDevice());
+
+		expect(bluetooth.requestDevice).toBe(realRequestDevice);
+	});
+
+	it('restores the real requestDevice when the library throws before using it', async () => {
+		const realRequestDevice = jest.fn();
+		const bluetooth = {requestDevice: realRequestDevice};
+		setNavigator({bluetooth});
+
+		mockedConnectGanCube.mockRejectedValue(new Error('boom'));
+
+		await expect(connectGanCubeDevice(fakeDevice())).rejects.toThrow(GanCubeConnectionError);
+		expect(bluetooth.requestDevice).toBe(realRequestDevice);
+	});
+
+	it('reports a helpful message when the cube exposes no GAN services', async () => {
+		setNavigator({bluetooth: {requestDevice: jest.fn()}});
+		mockedConnectGanCube.mockRejectedValue(
+			new Error("Can't find target BLE services - wrong or unsupported cube device model")
+		);
+
+		await expect(connectGanCubeDevice(fakeDevice())).rejects.toThrow(
+			/does not expose any of the GAN smart cube Bluetooth services/i
+		);
+	});
+
+	it('reports a helpful message when the MAC address could not be determined', async () => {
+		setNavigator({bluetooth: {requestDevice: jest.fn()}});
+		mockedConnectGanCube.mockRejectedValue(
+			new Error('Unable to determine cube MAC address, connection is not possible!')
+		);
+
+		await expect(connectGanCubeDevice(fakeDevice())).rejects.toThrow(/MAC address/i);
+	});
+
+	it('surfaces GATT drops as a retryable message', async () => {
+		setNavigator({bluetooth: {requestDevice: jest.fn()}});
+		mockedConnectGanCube.mockRejectedValue(
+			Object.assign(new Error('GATT Server is disconnected.'), {name: 'NetworkError'})
+		);
+
+		await expect(connectGanCubeDevice(fakeDevice())).rejects.toThrow(/Lost the Bluetooth connection/i);
+	});
+
+	it('fails cleanly when Web Bluetooth is unavailable', async () => {
+		setNavigator({});
+
+		await expect(connectGanCubeDevice(fakeDevice())).rejects.toThrow(/Web Bluetooth is not available/i);
+		expect(mockedConnectGanCube).not.toHaveBeenCalled();
+	});
+
+	it('errors are recognisable as smart cube connection errors', async () => {
+		setNavigator({});
+
+		await expect(connectGanCubeDevice(fakeDevice())).rejects.toBeInstanceOf(SmartCubeConnectionError);
+	});
+});
+
+describe('isGanCubeName', () => {
+	it.each(['GAN-1a2b3c', 'gan-1a2b3c', 'Gan-1a2b3c', 'MG-9f8e7d', 'AiCube-abc'])(
+		'matches %s',
+		(name) => {
+			expect(isGanCubeName(name)).toBe(true);
+		}
+	);
+
+	it.each(['GoCube-1234', 'Rubiks-1234', 'GiC123', 'Mi Smart Magic Cube', '', null, undefined])(
+		'does not match %s',
+		(name) => {
+			expect(isGanCubeName(name)).toBe(false);
+		}
+	);
+});
+
+describe('normalizeMacAddress', () => {
+	it.each([
+		['AB:CD:EF:12:34:56', 'AB:CD:EF:12:34:56'],
+		['ab:cd:ef:12:34:56', 'AB:CD:EF:12:34:56'],
+		['ab-cd-ef-12-34-56', 'AB:CD:EF:12:34:56'],
+		['abcdef123456', 'AB:CD:EF:12:34:56'],
+		['  AB CD EF 12 34 56  ', 'AB:CD:EF:12:34:56'],
+	])('normalizes %s', (input, expected) => {
+		expect(normalizeMacAddress(input)).toBe(expected);
+	});
+
+	it.each(['', null, undefined, 'not a mac', 'AB:CD:EF:12:34', 'AB:CD:EF:12:34:56:78', 'ZZ:CD:EF:12:34:56'])(
+		'rejects %s',
+		(input) => {
+			expect(normalizeMacAddress(input)).toBeNull();
+		}
+	);
+});
+
+describe('createMacAddressProvider', () => {
+	afterEach(() => {
+		delete (global as any).window;
+	});
+
+	it('returns null on the first call so the automatic lookup can run', async () => {
+		setLocalStorage();
+		const prompt = jest.fn();
+
+		const provider = createMacAddressProvider(prompt);
+		await expect(provider(fakeDevice(), false)).resolves.toBeNull();
+		expect(prompt).not.toHaveBeenCalled();
+	});
+
+	it('reuses a stored MAC address without prompting again', async () => {
+		setLocalStorage();
+		storeMacAddress('device-id', 'AB:CD:EF:12:34:56');
+		const prompt = jest.fn();
+
+		const provider = createMacAddressProvider(prompt);
+		await expect(provider(fakeDevice(), false)).resolves.toBe('AB:CD:EF:12:34:56');
+		expect(prompt).not.toHaveBeenCalled();
+	});
+
+	it('prompts once the automatic lookup has failed, and remembers the answer', async () => {
+		setLocalStorage();
+		const prompt = jest.fn().mockReturnValue('abcdef123456');
+
+		const provider = createMacAddressProvider(prompt);
+		await expect(provider(fakeDevice(), true)).resolves.toBe('AB:CD:EF:12:34:56');
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(readStoredMacAddress('device-id')).toBe('AB:CD:EF:12:34:56');
+	});
+
+	it('re-asks on a malformed MAC address rather than salting the key with garbage', async () => {
+		setLocalStorage();
+		const prompt = jest
+			.fn()
+			.mockReturnValueOnce('nonsense')
+			.mockReturnValueOnce('AB:CD:EF:12:34:56');
+
+		const provider = createMacAddressProvider(prompt);
+		await expect(provider(fakeDevice(), true)).resolves.toBe('AB:CD:EF:12:34:56');
+		expect(prompt).toHaveBeenCalledTimes(2);
+	});
+
+	it('gives up after repeated malformed entries', async () => {
+		setLocalStorage();
+		const prompt = jest.fn().mockReturnValue('nonsense');
+
+		const provider = createMacAddressProvider(prompt);
+		await expect(provider(fakeDevice(), true)).rejects.toThrow(/MAC address/i);
+	});
+
+	it('treats a dismissed prompt as a cancellation, not a failure', async () => {
+		setLocalStorage();
+		const prompt = jest.fn().mockReturnValue(null);
+
+		const provider = createMacAddressProvider(prompt);
+		await expect(provider(fakeDevice(), true)).rejects.toMatchObject({cancelled: true});
+		expect(prompt).toHaveBeenCalledTimes(1);
+	});
+
+	it('forgets a stored MAC address on request', () => {
+		setLocalStorage();
+		storeMacAddress('device-id', 'AB:CD:EF:12:34:56');
+		forgetStoredMacAddress('device-id');
+		expect(readStoredMacAddress('device-id')).toBeNull();
+	});
+
+	it('survives storage being unavailable', () => {
+		Object.defineProperty(global, 'window', {configurable: true, writable: true, value: {}});
+		expect(() => storeMacAddress('device-id', 'AB:CD:EF:12:34:56')).not.toThrow();
+		expect(readStoredMacAddress('device-id')).toBeNull();
+	});
+});
+
+describe('GAN_COMPANY_IDENTIFIERS', () => {
+	// Without these on requestDevice(), Chrome hides the manufacturer data that
+	// carries the cube's MAC address and every user gets prompted for it by hand.
+	it('covers the whole GAN company identifier range', () => {
+		expect(GAN_COMPANY_IDENTIFIERS).toHaveLength(256);
+		expect(GAN_COMPANY_IDENTIFIERS[0]).toBe(0x0001);
+		expect(GAN_COMPANY_IDENTIFIERS[255]).toBe(0xff01);
+		expect(GAN_COMPANY_IDENTIFIERS.every((id) => (id & 0xff) === 0x01)).toBe(true);
+	});
+});

--- a/client/components/timer/smart-cube/bluetooth/gan-cube/connect.ts
+++ b/client/components/timer/smart-cube/bluetooth/gan-cube/connect.ts
@@ -1,0 +1,310 @@
+import {SmartCubeConnectionError} from '@/components/timer/smart-cube/bluetooth/errors';
+import {connectGanCube, GanCubeConnection, MacAddressProvider} from 'gan-web-bluetooth';
+
+/**
+ * Primary services for the three GAN cube protocol generations.
+ *
+ * Gen2 covers the GAN356 i3 and the rest of the i Carry family, Gen3 the
+ * i Carry 2, and Gen4 the 12 ui Maglev / 14 ui FreePlay. All three have to be
+ * declared as optional services up front, otherwise `getPrimaryServices()`
+ * hides them and the library decides the cube is an unsupported model.
+ */
+export const GAN_CUBE_SERVICES = [
+	// Gen2 — GAN Mini ui FreePlay, GAN12 ui, GAN356 i Carry / i Carry S, GAN356 i3, Monster Go 3Ai
+	'6e400001-b5a3-f393-e0a9-e50e24dc4179',
+	// Gen3 — GAN356 i Carry 2
+	'8653000a-43e6-47b7-9cb0-5fc21d4ae340',
+	// Gen4 — GAN12 ui Maglev, GAN14 ui FreePlay
+	'00000010-0000-fff7-fff6-fff5fff4fff0',
+];
+
+/**
+ * GAN hardware advertises under a few different brands: "GAN-xxxx" for the
+ * mainline cubes, "MG" for Monster Go, and "AiCube" for the MoYu-branded AI
+ * cube. Casing varies by platform — macOS has been seen advertising lowercase.
+ */
+export const GAN_CUBE_NAME_PREFIXES = ['GAN', 'MG', 'AiCube'];
+
+/**
+ * GAN puts the cube's MAC address in the manufacturer-specific section of its
+ * BLE advertisement, under a company identifier whose low byte is always 0x01.
+ *
+ * Chrome strips manufacturer data for any company identifier that was not
+ * declared in `requestDevice()`, so the whole range has to be listed or the
+ * automatic MAC lookup comes back empty and every user gets asked to type their
+ * cube's MAC address in by hand.
+ */
+export const GAN_COMPANY_IDENTIFIERS = Array.from({length: 256}, (_, i) => (i << 8) | 0x01);
+
+/** Key prefix for MAC addresses the user had to enter manually. */
+const MAC_STORAGE_PREFIX = 'smart-cube-mac:';
+
+/** Attempts the user gets at typing a well-formed MAC address before we give up. */
+const MAC_PROMPT_ATTEMPTS = 3;
+
+/** Error raised when we cannot establish a usable connection to a GAN cube. */
+export class GanCubeConnectionError extends SmartCubeConnectionError {
+	constructor(message: string, options: {cancelled?: boolean; cause?: unknown} = {}) {
+		super(message, options);
+		this.name = 'GanCubeConnectionError';
+	}
+}
+
+/** True when `name` looks like one of the GAN smart cubes we can drive. */
+export function isGanCubeName(name: string | null | undefined): boolean {
+	if (!name) {
+		return false;
+	}
+
+	const lowered = name.toLowerCase();
+	return GAN_CUBE_NAME_PREFIXES.some((prefix) => lowered.startsWith(prefix.toLowerCase()));
+}
+
+/**
+ * Accept a MAC address in any of the shapes people actually paste — colons,
+ * dashes, spaces or nothing at all — and return the canonical `AB:CD:EF:12:34:56`
+ * form, or null when it is not a MAC address at all.
+ *
+ * Worth being strict about: the library turns the MAC into the salt for the
+ * cube's AES key, so a malformed one does not fail loudly, it just decrypts every
+ * packet into noise.
+ */
+export function normalizeMacAddress(value: string | null | undefined): string | null {
+	if (!value) {
+		return null;
+	}
+
+	const hex = value.trim().replace(/[^0-9a-f]/gi, '');
+	if (hex.length !== 12 || !/^[0-9a-f]{12}$/i.test(hex)) {
+		return null;
+	}
+
+	return (hex.toUpperCase().match(/.{2}/g) as string[]).join(':');
+}
+
+/** Read back a MAC address the user previously entered for this device. */
+export function readStoredMacAddress(deviceId: string): string | null {
+	if (!deviceId) {
+		return null;
+	}
+
+	try {
+		return normalizeMacAddress(window.localStorage.getItem(MAC_STORAGE_PREFIX + deviceId));
+	} catch {
+		// Storage can be unavailable in private windows. Not fatal, just means
+		// the user is asked again next time.
+		return null;
+	}
+}
+
+/** Remember a MAC address so the user only ever types it once per cube. */
+export function storeMacAddress(deviceId: string, mac: string): void {
+	if (!deviceId) {
+		return;
+	}
+
+	try {
+		window.localStorage.setItem(MAC_STORAGE_PREFIX + deviceId, mac);
+	} catch {
+		// See readStoredMacAddress — nothing we can do, and nothing worth failing for.
+	}
+}
+
+/** Forget a stored MAC address, so a bad entry can be corrected on the next attempt. */
+export function forgetStoredMacAddress(deviceId: string): void {
+	if (!deviceId) {
+		return;
+	}
+
+	try {
+		window.localStorage.removeItem(MAC_STORAGE_PREFIX + deviceId);
+	} catch {
+		// See readStoredMacAddress.
+	}
+}
+
+function manualMacPromptMessage(device: BluetoothDevice, attempt: number): string {
+	const lines: string[] = [];
+
+	if (attempt > 0) {
+		lines.push("That doesn't look like a MAC address. It should be 6 pairs of hex digits.");
+		lines.push('');
+	}
+
+	lines.push(`CubeDesk could not read the MAC address of "${device.name || 'your cube'}".`);
+	lines.push('GAN cubes need it before their Bluetooth data can be decoded.');
+	lines.push('');
+	lines.push('You can find it in the GAN Cube Station app under the cube’s details,');
+	lines.push('or on the sticker inside the battery compartment.');
+
+	if (typeof device.watchAdvertisements !== 'function') {
+		lines.push('');
+		lines.push('To let CubeDesk read it automatically instead, enable this Chrome flag');
+		lines.push('and reload: chrome://flags/#enable-experimental-web-platform-features');
+	}
+
+	lines.push('');
+	lines.push('MAC address (e.g. AB:CD:EF:12:34:56):');
+
+	return lines.join('\n');
+}
+
+/**
+ * Build the MAC address provider handed to `gan-web-bluetooth`.
+ *
+ * The library calls this twice: once before trying to read the MAC from the
+ * cube's advertisement (returning null there lets the automatic lookup run), and
+ * once more as a last resort if that came back empty.
+ *
+ * `promptForMac` is injectable so the prompt can be swapped out in tests.
+ */
+export function createMacAddressProvider(
+	promptForMac: (message: string) => string | null = (message) => window.prompt(message)
+): MacAddressProvider {
+	return async (device: BluetoothDevice, isFallbackCall?: boolean): Promise<string | null> => {
+		const stored = readStoredMacAddress(device.id);
+
+		if (!isFallbackCall) {
+			// A MAC we already know beats re-reading the advertisement, which is
+			// slow and needs a Chrome flag on most installs. Otherwise return null
+			// and let the library try the automatic lookup.
+			return stored;
+		}
+
+		// The automatic lookup failed. A stored value would already have been
+		// returned above, so this really is down to the user.
+		for (let attempt = 0; attempt < MAC_PROMPT_ATTEMPTS; attempt++) {
+			const entered = promptForMac(manualMacPromptMessage(device, attempt));
+
+			// Null means the user dismissed the prompt — stop asking.
+			if (entered === null) {
+				throw new GanCubeConnectionError('Cube connection was cancelled.', {cancelled: true});
+			}
+
+			const mac = normalizeMacAddress(entered);
+			if (mac) {
+				storeMacAddress(device.id, mac);
+				return mac;
+			}
+		}
+
+		throw new GanCubeConnectionError(
+			'CubeDesk could not determine your cube’s MAC address, which GAN cubes need before their Bluetooth data can be decoded.'
+		);
+	};
+}
+
+/**
+ * Temporarily make `bluetooth.requestDevice()` resolve to a device we already
+ * have, and hand back a function that undoes it.
+ *
+ * The override removes itself as soon as it is used, so the global is only
+ * patched for the brief synchronous window before the library takes the device,
+ * never while we sit awaiting GATT setup.
+ */
+function overrideRequestDevice(bluetooth: Bluetooth, device: BluetoothDevice): () => void {
+	const original = Object.getOwnPropertyDescriptor(bluetooth, 'requestDevice');
+
+	let restored = false;
+	const restore = () => {
+		if (restored) {
+			return;
+		}
+		restored = true;
+
+		if (original) {
+			Object.defineProperty(bluetooth, 'requestDevice', original);
+		} else {
+			Reflect.deleteProperty(bluetooth, 'requestDevice');
+		}
+	};
+
+	Object.defineProperty(bluetooth, 'requestDevice', {
+		configurable: true,
+		writable: true,
+		value: () => {
+			restore();
+			return Promise.resolve(device);
+		},
+	});
+
+	return restore;
+}
+
+/** Turn whatever the library threw into something worth showing a user. */
+function asConnectionError(err: unknown): GanCubeConnectionError {
+	if (err instanceof GanCubeConnectionError) {
+		return err;
+	}
+
+	const message = err instanceof Error ? err.message : String(err);
+	const name = (err as Error)?.name ?? '';
+
+	if (/unable to determine cube mac address/i.test(message)) {
+		return new GanCubeConnectionError(
+			'CubeDesk could not determine your cube’s MAC address, which GAN cubes need before their Bluetooth data can be decoded.',
+			{cause: err}
+		);
+	}
+
+	if (/can't find target ble services/i.test(message)) {
+		return new GanCubeConnectionError(
+			'That device does not expose any of the GAN smart cube Bluetooth services, so CubeDesk cannot read moves from it. Make sure you picked your cube and not a GAN Smart Timer or another nearby device.',
+			{cause: err}
+		);
+	}
+
+	if (name === 'NetworkError' || /gatt (server is disconnected|operation failed)/i.test(message)) {
+		return new GanCubeConnectionError(
+			'Lost the Bluetooth connection to the cube while setting it up. Give it a turn to wake it, close any other tab or app connected to it, then try again.',
+			{cause: err}
+		);
+	}
+
+	if (name === 'SecurityError' || /user gesture/i.test(message)) {
+		return new GanCubeConnectionError(
+			'The browser blocked the Bluetooth connection because it was not tied to a click. Press Connect again.',
+			{cause: err}
+		);
+	}
+
+	return new GanCubeConnectionError(
+		`Could not set up the cube connection${message ? `: ${message}` : '.'}`,
+		{cause: err}
+	);
+}
+
+/**
+ * Connect to a GAN smart cube that the user has already picked from the browser's
+ * device chooser.
+ *
+ * `gan-web-bluetooth` only exposes `connectGanCube()`, which opens a chooser of
+ * its own and has never accepted a pre-selected device. Calling it after our own
+ * chooser meant a second `requestDevice()` outside of a user gesture, which
+ * Chrome rejects outright — leaving the cube bonded with the OS ("paired") but
+ * never actually connected to CubeDesk. Feed the library the device it would
+ * otherwise have asked for.
+ */
+export async function connectGanCubeDevice(
+	device: BluetoothDevice,
+	macAddressProvider: MacAddressProvider = createMacAddressProvider()
+): Promise<GanCubeConnection> {
+	const bluetooth = typeof navigator === 'undefined' ? undefined : navigator.bluetooth;
+	if (!bluetooth) {
+		throw new GanCubeConnectionError(
+			'Web Bluetooth is not available in this browser. Try Chrome on desktop or Android, or Bluefy on iOS.'
+		);
+	}
+
+	const restore = overrideRequestDevice(bluetooth, device);
+
+	try {
+		return await connectGanCube(macAddressProvider);
+	} catch (err) {
+		throw asConnectionError(err);
+	} finally {
+		// No-op when the library already consumed the override, but the library
+		// can throw before reaching requestDevice() and the patch must not leak.
+		restore();
+	}
+}

--- a/client/components/timer/smart-cube/bluetooth/gan.ts
+++ b/client/components/timer/smart-cube/bluetooth/gan.ts
@@ -1,60 +1,154 @@
-// @ts-nocheck
+import {
+	connectGanCubeDevice,
+	createMacAddressProvider,
+} from '@/components/timer/smart-cube/bluetooth/gan-cube/connect';
 import SmartCube from '@/components/timer/smart-cube/bluetooth/smart_cube';
-import {	
-  connectGanCube,
-} from 'gan-web-bluetooth';
+import {GanCubeConnection, GanCubeEvent, MacAddressProvider} from 'gan-web-bluetooth';
+import {SubscriptionLike} from 'rxjs';
+
+/**
+ * How long to wait for the cube to answer REQUEST_HARDWARE before connecting
+ * anyway. The reply comes back asynchronously on the event stream, so the name
+ * is never available immediately after sending the command — reading it straight
+ * away registered every cube under an undefined name.
+ */
+const HARDWARE_INFO_TIMEOUT_MS = 2000;
 
 export default class GAN extends SmartCube {
-	device;
+	device: BluetoothDevice;
+	conn: GanCubeConnection | null = null;
+	subscription: SubscriptionLike | null = null;
 
-	constructor(device) {
+	hardwareName: string | null = null;
+	hardwareVersion: string | null = null;
+	softwareVersion: string | null = null;
+	productDate: string | null = null;
+	gyroSupported = false;
+
+	/** Resolves the in-flight wait in `waitForHardwareInfo`, if there is one. */
+	private onHardwareInfo: (() => void) | null = null;
+
+	private readonly macAddressProvider: MacAddressProvider;
+
+	constructor(device: BluetoothDevice, macAddressProvider: MacAddressProvider = createMacAddressProvider()) {
 		super();
 
 		this.device = device;
+		this.macAddressProvider = macAddressProvider;
 	}
 
-	customMacAddressProvider = async (device, isFallbackCall) => {
-		if (isFallbackCall) {
-			return prompt('Unable do determine cube MAC address!\nPlease enter MAC address manually:');
-		} else {
-			return typeof device.watchAdvertisements == 'function'
-				? null
-				: prompt(
-						'Seems like your browser does not support Web Bluetooth watchAdvertisements() API. Enable following flag in Chrome:\n\nchrome://flags/#enable-experimental-web-platform-features\n\nor enter cube MAC address manually:'
-				  );
+	init = async (): Promise<void> => {
+		const conn = await connectGanCubeDevice(this.device, this.macAddressProvider);
+		this.conn = conn;
+
+		// From here on we hold a live GATT link. Anything that fails during setup
+		// has to hang it up again, otherwise the cube sits there connected to
+		// nothing and refuses to pair with the next attempt.
+		try {
+			this.subscription = conn.events$.subscribe({
+				next: this.handleCubeEvent,
+				error: (err: unknown) => {
+					console.error('[GanCube] event stream error', err);
+					this.alertDisconnected();
+				},
+			});
+
+			// Ask for the hardware name first — `alertConnected` needs it to
+			// register the cube — then battery and the current facelet state.
+			await conn.sendCubeCommand({type: 'REQUEST_HARDWARE'});
+			await conn.sendCubeCommand({type: 'REQUEST_BATTERY'});
+			await conn.sendCubeCommand({type: 'REQUEST_FACELETS'});
+
+			await this.waitForHardwareInfo();
+
+			await this.alertConnected({
+				device: {
+					name: this.hardwareName || conn.deviceName || this.device.name || 'GAN Smart Cube',
+					id: this.device.id,
+				},
+			});
+		} catch (err) {
+			await this.disconnect();
+			throw err;
 		}
 	};
 
-	init = async () => {
-		this.conn = await connectGanCube(this.customMacAddressProvider, this.device);
-		this.conn.events$.subscribe(this.handleCubeEvent);
+	/**
+	 * Wait for the cube to report its hardware details, but never block the
+	 * connection on it — a cube that stays quiet is still perfectly usable, it
+	 * just gets registered under its advertised name instead.
+	 */
+	private waitForHardwareInfo = (): Promise<void> => {
+		if (this.hardwareName) {
+			return Promise.resolve();
+		}
 
-		await this.conn.sendCubeCommand({ type: "REQUEST_BATTERY" });
-		await this.conn.sendCubeCommand({ type: "REQUEST_HARDWARE" });
+		return new Promise<void>((resolve) => {
+			const finish = () => {
+				clearTimeout(timeout);
+				this.onHardwareInfo = null;
+				resolve();
+			};
 
-		const dummyServer = {
-			device: {
-				name: this.hardwareName,
-				id: this.device.mac
-			}
-		};
-		this.alertConnected(dummyServer);
+			const timeout = setTimeout(finish, HARDWARE_INFO_TIMEOUT_MS);
+			this.onHardwareInfo = finish;
+		});
 	};
 
-	handleCubeEvent = (event) => {
-		if (event.type != 'GYRO' && event.type != 'FACELETS') console.log('GanCubeEvent', event);
-		if (event.type == 'MOVE') {
-			this.alertTurnCube(event.move);
-		}  else if (event.type == 'HARDWARE') {
-			this.hardwareName = event.hardwareName;
-			this.hardwareVersion = event.hardwareVersion;
-			this.softwareVersion = event.softwareVersion;
-			this.productDate = event.productDate;
-			this.gyroSupported = event.gyroSupported;
-		} else if (event.type == 'BATTERY') {
-			this.alertBatteryLevel(this.batteryLevel);
-		} else if (event.type == 'DISCONNECT') {
-			this.alertDisconnected();
+	handleCubeEvent = (event: GanCubeEvent): void => {
+		switch (event.type) {
+			case 'MOVE': {
+				this.alertTurnCube(event.move);
+				break;
+			}
+			case 'FACELETS': {
+				// Kociemba notation, which is what the visual cube expects.
+				this.alertCubeState(event.facelets);
+				break;
+			}
+			case 'HARDWARE': {
+				this.hardwareName = event.hardwareName ?? null;
+				this.hardwareVersion = event.hardwareVersion ?? null;
+				this.softwareVersion = event.softwareVersion ?? null;
+				this.productDate = event.productDate ?? null;
+				this.gyroSupported = event.gyroSupported ?? false;
+
+				this.onHardwareInfo?.();
+				break;
+			}
+			case 'BATTERY': {
+				// The level rides on the event. Reading it off `this` instead left
+				// the battery indicator permanently empty.
+				this.alertBatteryLevel(event.batteryLevel);
+				break;
+			}
+			case 'GYRO': {
+				// Orientation updates, streamed continuously. Nothing uses them yet,
+				// and they must never reach the move handler.
+				break;
+			}
+			case 'DISCONNECT': {
+				this.alertDisconnected();
+				break;
+			}
+		}
+	};
+
+	/**
+	 * Close the connection. Unsubscribes first so an intentional disconnect does
+	 * not surface as a "Smart cube disconnected" error toast.
+	 */
+	disconnect = async (): Promise<void> => {
+		this.subscription?.unsubscribe();
+		this.subscription = null;
+
+		this.onHardwareInfo?.();
+
+		const conn = this.conn;
+		this.conn = null;
+
+		if (conn) {
+			await conn.disconnect().catch(() => undefined);
 		}
 	};
 }

--- a/client/components/timer/time-display/GanTimer.tsx
+++ b/client/components/timer/time-display/GanTimer.tsx
@@ -1,6 +1,7 @@
 import {openModal} from '@/actions/general';
 import Emblem from '@/components/common/Emblem';
 import BluetoothErrorMessage from '@/components/timer/common/BluetoothErrorMessage';
+import GanTimerErrorMessage from '@/components/timer/common/GanTimerErrorMessage';
 import {
 	cancelInspection,
 	endTimer,
@@ -8,11 +9,16 @@ import {
 	startTimer,
 } from '@/components/timer/helpers/events';
 import {setTimerParams} from '@/components/timer/helpers/params';
+import {
+	connectGanTimer,
+	GanTimerConnection,
+	GanTimerConnectionError,
+} from '@/components/timer/time-display/gan-timer/connect';
+import {GanTimerEvent, GanTimerState} from '@/components/timer/time-display/gan-timer/protocol';
 import {ITimerContext, useTimerContext} from '@/components/timer/Timer';
 import {useSettings} from '@/util/hooks/useSettings';
-import {connectGanTimer, GanTimerConnection, GanTimerEvent, GanTimerState} from 'gan-web-bluetooth';
 import {Bluetooth} from 'phosphor-react';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useDispatch} from 'react-redux';
 import {SubscriptionLike} from 'rxjs';
 
@@ -25,20 +31,14 @@ let subs: SubscriptionLike | null = null;
 export default function GanTimer() {
 	const dispatch = useDispatch();
 	const inspectionEnabled = useSettings('inspection');
-	const [connected, setConnected] = useState(false);
+	const [connected, setConnected] = useState(!!conn);
+	const [connecting, setConnecting] = useState(false);
 
 	const context = useTimerContext();
 	const contextRef = useRef<ITimerContext>(context);
 	useEffect(() => {
 		contextRef.current = context;
 	}, [context]);
-
-	// Subscribe/unsubscribe to GAN Smart Timer events when component being mounted/unmounted
-	useEffect(() => {
-		subs = conn?.events$.subscribe(handleTimerEvent) ?? null;
-		setConnected(!!conn);
-		return () => subs?.unsubscribe();
-	}, []);
 
 	function handleTimerEvent(event: GanTimerEvent) {
 		switch (event.state) {
@@ -60,6 +60,9 @@ export default function GanTimer() {
 					endTimer(contextRef.current, event.recordedTime.asTimestamp);
 				}
 				break;
+			case GanTimerState.FINISHED:
+				// Emitted immediately after STOPPED, which already recorded the solve.
+				break;
 			case GanTimerState.IDLE:
 				if (
 					!inspectionEnabled ||
@@ -73,39 +76,100 @@ export default function GanTimer() {
 				}
 				break;
 			case GanTimerState.DISCONNECT:
+				conn = null;
 				setConnected(false);
 				break;
 		}
 	}
 
+	// The subscription outlives individual renders, so route events through a ref.
+	// Reading the handler off the ref keeps settings like inspection up to date
+	// instead of freezing whatever they were when the timer was connected.
+	const handlerRef = useRef(handleTimerEvent);
+	handlerRef.current = handleTimerEvent;
+
+	const subscribe = useCallback((connection: GanTimerConnection): SubscriptionLike => {
+		return connection.events$.subscribe({
+			next: (event: GanTimerEvent) => handlerRef.current(event),
+			// The driver drops bad packets rather than erroring, but never let an
+			// unexpected stream error escape as an unhandled rejection.
+			error: (err: unknown) => {
+				console.error('[GanTimer] event stream error', err);
+				conn = null;
+				setConnected(false);
+			},
+		});
+	}, []);
+
+	// Re-attach to an existing connection when this component is remounted
+	useEffect(() => {
+		subs?.unsubscribe();
+		subs = conn ? subscribe(conn) : null;
+		setConnected(!!conn);
+		return () => subs?.unsubscribe();
+	}, [subscribe]);
+
 	async function handleConnectButton() {
+		if (connecting) {
+			return;
+		}
+
 		if (conn) {
-			conn.disconnect();
+			const closing = conn;
 			conn = null;
+			subs?.unsubscribe();
+			subs = null;
 			setConnected(false);
-		} else {
+			await closing.disconnect().catch(() => undefined);
+			return;
+		}
+
+		setConnecting(true);
+		try {
 			const bluetoothAvailable =
 				!!navigator.bluetooth && (await navigator.bluetooth.getAvailability());
-			if (bluetoothAvailable) {
-				conn = await connectGanTimer();
-				conn.events$.subscribe(
-					(evt) => evt.state == GanTimerState.DISCONNECT && (conn = null),
-				);
-				subs = conn.events$.subscribe(handleTimerEvent);
-				setConnected(true);
-			} else {
+			if (!bluetoothAvailable) {
 				dispatch(openModal(<BluetoothErrorMessage />));
+				return;
 			}
+
+			const connection = await connectGanTimer();
+			conn = connection;
+			subs?.unsubscribe();
+			subs = subscribe(connection);
+			setConnected(true);
+		} catch (err) {
+			conn = null;
+			setConnected(false);
+
+			// The user just closed the browser's device chooser; nothing to report.
+			if (err instanceof GanTimerConnectionError && err.cancelled) {
+				return;
+			}
+
+			console.error('[GanTimer] connection failed', err);
+			const message =
+				err instanceof Error ? err.message : 'An unknown error occurred while connecting.';
+			dispatch(openModal(<GanTimerErrorMessage message={message} />));
+		} finally {
+			setConnecting(false);
 		}
+	}
+
+	let text = 'Connect to Timer';
+	if (connecting) {
+		text = 'Connecting...';
+	} else if (connected) {
+		text = 'Connected';
 	}
 
 	return (
 		<div onClick={handleConnectButton} style={{userSelect: 'none', cursor: 'pointer'}}>
 			<Emblem
 				icon={<Bluetooth />}
-				text={connected ? 'Connected' : 'Connect to Timer'}
+				text={text}
 				small
-				red={!connected}
+				red={!connected && !connecting}
 				green={connected}
 			/>
 		</div>

--- a/client/components/timer/time-display/gan-timer/connect.test.ts
+++ b/client/components/timer/time-display/gan-timer/connect.test.ts
@@ -1,0 +1,341 @@
+import {
+	connectGanTimer,
+	GAN_TIMER_SERVICE,
+	GAN_TIMER_STATE_CHARACTERISTIC,
+	GAN_TIMER_TIME_CHARACTERISTIC,
+	GanTimerConnectionError,
+} from '@/components/timer/time-display/gan-timer/connect';
+import {crc16ccit, GanTimerState} from '@/components/timer/time-display/gan-timer/protocol';
+
+function buildPacket(state: number, payload: number[] = []): DataView {
+	const body = [0xfe, 0x00, 0x00, state, ...payload];
+	const crc = crc16ccit(new Uint8Array(body.slice(2)).buffer);
+	return new DataView(new Uint8Array([...body, crc & 0xff, (crc >> 8) & 0xff]).buffer);
+}
+
+class FakeCharacteristic {
+	uuid: string;
+	listeners: ((evt: {target: {value: DataView}}) => void)[] = [];
+	startNotifications = jest.fn().mockResolvedValue(undefined);
+	stopNotifications = jest.fn().mockResolvedValue(undefined);
+	readValue = jest.fn();
+
+	constructor(uuid: string) {
+		this.uuid = uuid;
+	}
+
+	addEventListener(_type: string, cb: (evt: {target: {value: DataView}}) => void) {
+		this.listeners.push(cb);
+	}
+
+	removeEventListener(_type: string, cb: (evt: {target: {value: DataView}}) => void) {
+		this.listeners = this.listeners.filter((l) => l !== cb);
+	}
+
+	/** Simulate the timer pushing a notification */
+	emit(value: DataView) {
+		this.listeners.forEach((cb) => cb({target: {value}}));
+	}
+}
+
+interface FakeServiceOptions {
+	uuid?: string;
+	characteristics?: string[];
+	failGetCharacteristic?: string[];
+}
+
+class FakeService {
+	uuid: string;
+	characteristics = new Map<string, FakeCharacteristic>();
+	private failFor: string[];
+
+	constructor({uuid = GAN_TIMER_SERVICE, characteristics, failGetCharacteristic = []}: FakeServiceOptions = {}) {
+		this.uuid = uuid;
+		this.failFor = failGetCharacteristic;
+		const uuids = characteristics ?? [GAN_TIMER_TIME_CHARACTERISTIC, GAN_TIMER_STATE_CHARACTERISTIC];
+		uuids.forEach((u) => this.characteristics.set(u, new FakeCharacteristic(u)));
+	}
+
+	async getCharacteristic(uuid: string) {
+		if (this.failFor.includes(uuid)) {
+			throw new Error(`No Characteristics matching UUID ${uuid} found in Service.`);
+		}
+		const chr = this.characteristics.get(uuid);
+		if (!chr) {
+			throw new Error(`No Characteristics matching UUID ${uuid} found in Service.`);
+		}
+		return chr;
+	}
+}
+
+interface FakeDeviceOptions {
+	services?: FakeService[];
+	/** Number of getPrimaryService calls that should fail before succeeding */
+	primaryServiceFailures?: number;
+	/** Make getPrimaryService always fail, forcing the getPrimaryServices fallback */
+	primaryServiceAlwaysFails?: boolean;
+	gattConnectFailures?: number;
+}
+
+class FakeDevice {
+	name = 'GAN Timer';
+	listeners: Record<string, (() => void)[]> = {};
+	gatt: {
+		connected: boolean;
+		connect: jest.Mock;
+		disconnect: jest.Mock;
+		getPrimaryService: jest.Mock;
+		getPrimaryServices: jest.Mock;
+	};
+
+	constructor(options: FakeDeviceOptions = {}) {
+		const services = options.services ?? [new FakeService()];
+		let primaryServiceCalls = 0;
+		let gattConnectCalls = 0;
+
+		this.gatt = {
+			connected: false,
+			connect: jest.fn(async () => {
+				gattConnectCalls++;
+				if (gattConnectCalls <= (options.gattConnectFailures ?? 0)) {
+					throw new Error('GATT operation failed for unknown reason.');
+				}
+				this.gatt.connected = true;
+				return this.gatt;
+			}),
+			disconnect: jest.fn(() => {
+				this.gatt.connected = false;
+			}),
+			getPrimaryService: jest.fn(async (uuid: string) => {
+				primaryServiceCalls++;
+				if (
+					options.primaryServiceAlwaysFails ||
+					primaryServiceCalls <= (options.primaryServiceFailures ?? 0)
+				) {
+					throw new Error(`No Services matching UUID ${uuid} found in Device.`);
+				}
+				const svc = services.find((s) => s.uuid === uuid);
+				if (!svc) {
+					throw new Error(`No Services matching UUID ${uuid} found in Device.`);
+				}
+				return svc;
+			}),
+			getPrimaryServices: jest.fn(async () => services),
+		};
+	}
+
+	addEventListener(type: string, cb: () => void) {
+		(this.listeners[type] ??= []).push(cb);
+	}
+
+	removeEventListener(type: string, cb: () => void) {
+		this.listeners[type] = (this.listeners[type] ?? []).filter((l) => l !== cb);
+	}
+
+	emit(type: string) {
+		[...(this.listeners[type] ?? [])].forEach((cb) => cb());
+	}
+}
+
+/** Node exposes `navigator` as a non-writable accessor, so redefine it outright */
+function setNavigator(value: unknown) {
+	Object.defineProperty(global, 'navigator', {value, configurable: true, writable: true});
+}
+
+function mockBluetooth(device: FakeDevice, requestDevice?: jest.Mock) {
+	const request = requestDevice ?? jest.fn().mockResolvedValue(device);
+	setNavigator({
+		bluetooth: {
+			getAvailability: jest.fn().mockResolvedValue(true),
+			requestDevice: request,
+		},
+	});
+	return request;
+}
+
+// Zero delay so the retry paths don't slow the suite down
+const options = {retryDelayMs: 0};
+
+describe('connectGanTimer', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('offers the timer service as a device filter, not just name prefixes', async () => {
+		const device = new FakeDevice();
+		const requestDevice = mockBluetooth(device);
+
+		await connectGanTimer(options);
+
+		const filters = requestDevice.mock.calls[0][0].filters;
+		expect(filters).toEqual(
+			expect.arrayContaining([
+				{namePrefix: 'GAN'},
+				{namePrefix: 'Gan'},
+				{namePrefix: 'gan'},
+				{services: [GAN_TIMER_SERVICE]},
+			])
+		);
+		expect(requestDevice.mock.calls[0][0].optionalServices).toContain(GAN_TIMER_SERVICE);
+	});
+
+	it('connects when the timer only exposes the state characteristic', async () => {
+		// The time characteristic is optional: CubeDesk never reads recorded times,
+		// so a timer that does not expose fff2 must still connect.
+		const service = new FakeService({characteristics: [GAN_TIMER_STATE_CHARACTERISTIC]});
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+
+		expect(conn).toBeTruthy();
+		await expect(conn.getRecordedTimes()).rejects.toBeInstanceOf(GanTimerConnectionError);
+	});
+
+	it('retries service discovery when the first lookup fails', async () => {
+		const device = new FakeDevice({primaryServiceFailures: 2});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+
+		expect(conn).toBeTruthy();
+		expect(device.gatt.getPrimaryService).toHaveBeenCalledTimes(3);
+	});
+
+	it('falls back to enumerating services when lookup by UUID never succeeds', async () => {
+		// Chrome on macOS can report the service with a different UUID casing or
+		// refuse a direct lookup while still listing it.
+		const service = new FakeService({uuid: GAN_TIMER_SERVICE.toUpperCase()});
+		const device = new FakeDevice({services: [service], primaryServiceAlwaysFails: true});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+
+		expect(conn).toBeTruthy();
+		expect(device.gatt.getPrimaryServices).toHaveBeenCalled();
+	});
+
+	it('retries a failed GATT connection', async () => {
+		const device = new FakeDevice({gattConnectFailures: 1});
+		mockBluetooth(device);
+
+		await connectGanTimer(options);
+
+		expect(device.gatt.connect).toHaveBeenCalledTimes(2);
+	});
+
+	it('awaits startNotifications and fails the connect if it never succeeds', async () => {
+		const service = new FakeService();
+		const state = await service.getCharacteristic(GAN_TIMER_STATE_CHARACTERISTIC);
+		state.startNotifications.mockRejectedValue(new Error('GATT operation failed'));
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		await expect(connectGanTimer(options)).rejects.toBeInstanceOf(GanTimerConnectionError);
+	});
+
+	it('tears down the GATT link when setup fails, so the timer does not stay connected', async () => {
+		// This is the reported symptom: the timer shows connected while the app does not.
+		const service = new FakeService({characteristics: []});
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		await expect(connectGanTimer(options)).rejects.toBeInstanceOf(GanTimerConnectionError);
+		expect(device.gatt.disconnect).toHaveBeenCalled();
+		expect(device.gatt.connected).toBe(false);
+	});
+
+	it('emits decoded events from state notifications', async () => {
+		const service = new FakeService();
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+		const events: number[] = [];
+		conn.events$.subscribe((e) => events.push(e.state));
+
+		const state = await service.getCharacteristic(GAN_TIMER_STATE_CHARACTERISTIC);
+		state.emit(buildPacket(GanTimerState.HANDS_ON));
+		state.emit(buildPacket(GanTimerState.RUNNING));
+
+		expect(events).toEqual([GanTimerState.HANDS_ON, GanTimerState.RUNNING]);
+	});
+
+	it('drops an invalid packet but keeps the stream alive', async () => {
+		// A single corrupt notification must not permanently kill the timer.
+		const service = new FakeService();
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+		const events: number[] = [];
+		const errors: unknown[] = [];
+		conn.events$.subscribe({next: (e) => events.push(e.state), error: (e) => errors.push(e)});
+
+		const state = await service.getCharacteristic(GAN_TIMER_STATE_CHARACTERISTIC);
+		state.emit(new DataView(new Uint8Array([0x00, 0x01, 0x02]).buffer));
+		state.emit(buildPacket(GanTimerState.RUNNING));
+
+		expect(errors).toEqual([]);
+		expect(events).toEqual([GanTimerState.RUNNING]);
+	});
+
+	it('emits DISCONNECT when the device drops the link', async () => {
+		const device = new FakeDevice();
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+		const events: number[] = [];
+		conn.events$.subscribe((e) => events.push(e.state));
+
+		device.emit('gattserverdisconnected');
+
+		expect(events).toEqual([GanTimerState.DISCONNECT]);
+	});
+
+	it('emits DISCONNECT exactly once when disconnect races with the hardware event', async () => {
+		const device = new FakeDevice();
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+		const events: number[] = [];
+		conn.events$.subscribe((e) => events.push(e.state));
+
+		await conn.disconnect();
+		device.emit('gattserverdisconnected');
+		await conn.disconnect();
+
+		expect(events).toEqual([GanTimerState.DISCONNECT]);
+	});
+
+	it('reads recorded times when the time characteristic is present', async () => {
+		const service = new FakeService();
+		const time = await service.getCharacteristic(GAN_TIMER_TIME_CHARACTERISTIC);
+		const bytes = new Uint8Array(16);
+		bytes.set([0, 12, 0x34, 0x01], 0); // 0:12.308
+		time.readValue.mockResolvedValue(new DataView(bytes.buffer));
+
+		const device = new FakeDevice({services: [service]});
+		mockBluetooth(device);
+
+		const conn = await connectGanTimer(options);
+		const times = await conn.getRecordedTimes();
+
+		expect(times.displayTime.asTimestamp).toBe(12308);
+		expect(times.previousTimes).toHaveLength(3);
+	});
+
+	it('surfaces a cancelled device chooser as a cancellation, not a failure', async () => {
+		const abort = new Error('User cancelled the requestDevice() chooser.');
+		abort.name = 'NotFoundError';
+		mockBluetooth(new FakeDevice(), jest.fn().mockRejectedValue(abort));
+
+		await expect(connectGanTimer(options)).rejects.toMatchObject({cancelled: true});
+	});
+
+	it('reports a missing Web Bluetooth implementation clearly', async () => {
+		setNavigator({});
+
+		await expect(connectGanTimer(options)).rejects.toBeInstanceOf(GanTimerConnectionError);
+	});
+});

--- a/client/components/timer/time-display/gan-timer/connect.ts
+++ b/client/components/timer/time-display/gan-timer/connect.ts
@@ -1,0 +1,318 @@
+import {
+	buildTimerEvent,
+	GanTimerEvent,
+	GanTimerRecordedTimes,
+	GanTimerState,
+	hexdump,
+	isValidEventData,
+	makeTimeFromRaw,
+	normalizeUuid,
+} from '@/components/timer/time-display/gan-timer/protocol';
+import {Observable, Subject} from 'rxjs';
+
+// GAN Smart Timer bluetooth service and characteristic UUIDs
+export const GAN_TIMER_SERVICE = '0000fff0-0000-1000-8000-00805f9b34fb';
+export const GAN_TIMER_TIME_CHARACTERISTIC = '0000fff2-0000-1000-8000-00805f9b34fb';
+export const GAN_TIMER_STATE_CHARACTERISTIC = '0000fff5-0000-1000-8000-00805f9b34fb';
+
+// GAN timers report themselves under a handful of casings depending on the OS.
+// macOS in particular has been seen advertising the lowercase variant.
+const NAME_PREFIXES = ['GAN', 'Gan', 'gan'];
+
+const DEFAULT_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 250;
+
+export interface GanTimerConnectOptions {
+	/** Attempts made for each flaky GATT operation. Exposed for tests. */
+	retries?: number;
+	/** Delay between attempts. Exposed for tests. */
+	retryDelayMs?: number;
+}
+
+/**
+ * Error raised when we cannot establish a usable connection to the timer.
+ *
+ * `cancelled` marks the case where the user simply dismissed the browser's
+ * device chooser, which should not be reported to them as a failure.
+ */
+export class GanTimerConnectionError extends Error {
+	readonly cancelled: boolean;
+	readonly cause?: unknown;
+
+	constructor(message: string, {cancelled = false, cause}: {cancelled?: boolean; cause?: unknown} = {}) {
+		super(message);
+		this.name = 'GanTimerConnectionError';
+		this.cancelled = cancelled;
+		this.cause = cause;
+	}
+}
+
+/** Connection object representing the timer connection API and state */
+export interface GanTimerConnection {
+	/** Stream of timer state events */
+	events$: Observable<GanTimerEvent>;
+	/** Retrieve the last times recorded by the timer */
+	getRecordedTimes(): Promise<GanTimerRecordedTimes>;
+	/** Disconnect from the timer */
+	disconnect(): Promise<void>;
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Retry a flaky GATT operation.
+ *
+ * Chrome's Web Bluetooth stack — especially on macOS, where CoreBluetooth caches
+ * GATT attributes — regularly fails the first service or characteristic lookup
+ * right after connecting, then succeeds on a second attempt.
+ */
+async function withRetry<T>(operation: () => Promise<T>, retries: number, retryDelayMs: number): Promise<T> {
+	let lastError: unknown;
+
+	for (let attempt = 0; attempt < retries; attempt++) {
+		try {
+			return await operation();
+		} catch (err) {
+			lastError = err;
+			if (attempt < retries - 1) {
+				await delay(retryDelayMs);
+			}
+		}
+	}
+
+	throw lastError;
+}
+
+/** True when the rejection means "the user closed the device chooser" */
+function isChooserCancellation(err: unknown): boolean {
+	const name = (err as Error)?.name;
+	const message = (err as Error)?.message ?? '';
+	return (
+		name === 'AbortError' ||
+		(name === 'NotFoundError' && /cancell?ed|chooser|user/i.test(message))
+	);
+}
+
+async function requestTimerDevice(): Promise<BluetoothDevice> {
+	if (typeof navigator === 'undefined' || !navigator.bluetooth) {
+		throw new GanTimerConnectionError(
+			'Web Bluetooth is not available in this browser. Try Chrome on desktop or Android, or Bluefy on iOS.'
+		);
+	}
+
+	try {
+		return await navigator.bluetooth.requestDevice({
+			filters: [
+				...NAME_PREFIXES.map((namePrefix) => ({namePrefix})),
+				// Match on the advertised service too. Not every timer presents a
+				// name the browser will surface, and without this they never show
+				// up in the chooser at all.
+				{services: [GAN_TIMER_SERVICE]},
+			],
+			optionalServices: [GAN_TIMER_SERVICE],
+		});
+	} catch (err) {
+		if (isChooserCancellation(err)) {
+			throw new GanTimerConnectionError('Timer selection was cancelled.', {
+				cancelled: true,
+				cause: err,
+			});
+		}
+		throw new GanTimerConnectionError(
+			'Could not open the Bluetooth device chooser. Make sure Bluetooth is turned on and this page is served over HTTPS.',
+			{cause: err}
+		);
+	}
+}
+
+/**
+ * Locate the timer service.
+ *
+ * Looking the service up by UUID is the fast path, but it is also the operation
+ * that fails most often in the wild, so fall back to enumerating every primary
+ * service and matching the UUID ourselves.
+ */
+async function resolveTimerService(
+	server: BluetoothRemoteGATTServer,
+	{retries, retryDelayMs}: Required<GanTimerConnectOptions>
+): Promise<BluetoothRemoteGATTService> {
+	try {
+		return await withRetry(() => server.getPrimaryService(GAN_TIMER_SERVICE), retries, retryDelayMs);
+	} catch (lookupError) {
+		let services: BluetoothRemoteGATTService[];
+		try {
+			services = await withRetry(() => server.getPrimaryServices(), retries, retryDelayMs);
+		} catch {
+			throw new GanTimerConnectionError(
+				'Connected to the timer, but its Bluetooth services could not be read. Turn the timer off and on, then try again.',
+				{cause: lookupError}
+			);
+		}
+
+		const service = services.find((s) => normalizeUuid(s.uuid) === GAN_TIMER_SERVICE);
+		if (!service) {
+			const found = services.map((s) => normalizeUuid(s.uuid)).join(', ') || 'none';
+			throw new GanTimerConnectionError(
+				`This device does not expose the GAN Smart Timer service. Services found: ${found}.`,
+				{cause: lookupError}
+			);
+		}
+
+		return service;
+	}
+}
+
+/**
+ * Connect to a GAN Smart Timer over Web Bluetooth.
+ *
+ * Written against the same protocol as `gan-web-bluetooth`, but deliberately
+ * more forgiving about how the device presents itself: the time characteristic
+ * is optional, service discovery is retried, and a malformed notification is
+ * dropped rather than tearing down the event stream.
+ */
+export async function connectGanTimer(
+	options: GanTimerConnectOptions = {}
+): Promise<GanTimerConnection> {
+	const settings: Required<GanTimerConnectOptions> = {
+		retries: options.retries ?? DEFAULT_RETRIES,
+		retryDelayMs: options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS,
+	};
+
+	const device = await requestTimerDevice();
+
+	if (!device.gatt) {
+		throw new GanTimerConnectionError('The selected device does not support GATT connections.');
+	}
+	const gatt = device.gatt;
+
+	let server: BluetoothRemoteGATTServer;
+	try {
+		server = await withRetry(() => gatt.connect(), settings.retries, settings.retryDelayMs);
+	} catch (err) {
+		throw new GanTimerConnectionError(
+			'Could not connect to the timer. Make sure it is switched on and not already paired with another app or tab.',
+			{cause: err}
+		);
+	}
+
+	// From here on the device is connected, and will show itself as connected on
+	// its own display. Anything that goes wrong has to hang the link up again,
+	// otherwise the timer sits there looking connected while CubeDesk is not.
+	try {
+		const service = await resolveTimerService(server, settings);
+
+		const stateCharacteristic = await withRetry(
+			() => service.getCharacteristic(GAN_TIMER_STATE_CHARACTERISTIC),
+			settings.retries,
+			settings.retryDelayMs
+		).catch((err) => {
+			throw new GanTimerConnectionError(
+				'The timer did not expose its state characteristic, so CubeDesk cannot receive solve events from it.',
+				{cause: err}
+			);
+		});
+
+		// Only used by getRecordedTimes(). A timer that does not expose it is
+		// still perfectly usable, so never let this block the connection.
+		const timeCharacteristic = await service
+			.getCharacteristic(GAN_TIMER_TIME_CHARACTERISTIC)
+			.catch(() => null);
+
+		const eventSubject = new Subject<GanTimerEvent>();
+
+		const onStateChanged = (evt: Event) => {
+			const data = (evt.target as BluetoothRemoteGATTCharacteristic)?.value;
+			if (!isValidEventData(data)) {
+				// Log and move on. Erroring the stream here would permanently kill
+				// the timer over a single corrupt packet.
+				console.warn('[GanTimer] discarding invalid packet from timer:', hexdump(data));
+				return;
+			}
+
+			const event = buildTimerEvent(data as DataView);
+			if (event) {
+				eventSubject.next(event);
+			}
+		};
+
+		stateCharacteristic.addEventListener('characteristicvaluechanged', onStateChanged);
+
+		try {
+			await withRetry(
+				() => stateCharacteristic.startNotifications(),
+				settings.retries,
+				settings.retryDelayMs
+			);
+		} catch (err) {
+			stateCharacteristic.removeEventListener('characteristicvaluechanged', onStateChanged);
+			throw new GanTimerConnectionError(
+				'Connected to the timer, but CubeDesk could not subscribe to its updates. Turn the timer off and on, then try again.',
+				{cause: err}
+			);
+		}
+
+		let closed = false;
+		const teardown = async () => {
+			if (closed) {
+				return;
+			}
+			closed = true;
+
+			device.removeEventListener('gattserverdisconnected', onGattDisconnected);
+			stateCharacteristic.removeEventListener('characteristicvaluechanged', onStateChanged);
+
+			// Announce the disconnect synchronously so the UI reacts immediately,
+			// then let the GATT teardown finish in the background.
+			eventSubject.next({state: GanTimerState.DISCONNECT});
+			eventSubject.complete();
+
+			if (gatt.connected) {
+				await stateCharacteristic.stopNotifications().catch(() => undefined);
+				gatt.disconnect();
+			}
+		};
+
+		function onGattDisconnected() {
+			void teardown();
+		}
+
+		device.addEventListener('gattserverdisconnected', onGattDisconnected);
+
+		return {
+			events$: eventSubject.asObservable(),
+			disconnect: teardown,
+			getRecordedTimes: async (): Promise<GanTimerRecordedTimes> => {
+				if (!timeCharacteristic) {
+					throw new GanTimerConnectionError(
+						'This timer does not expose its recorded times.'
+					);
+				}
+
+				const data = await timeCharacteristic.readValue();
+				if (!data || data.byteLength < 16) {
+					throw new GanTimerConnectionError(
+						'Invalid time value received from the timer.'
+					);
+				}
+
+				return {
+					displayTime: makeTimeFromRaw(data, 0),
+					previousTimes: [
+						makeTimeFromRaw(data, 4),
+						makeTimeFromRaw(data, 8),
+						makeTimeFromRaw(data, 12),
+					],
+				};
+			},
+		};
+	} catch (err) {
+		if (gatt.connected) {
+			gatt.disconnect();
+		}
+		throw err instanceof GanTimerConnectionError
+			? err
+			: new GanTimerConnectionError('Could not set up the timer connection.', {cause: err});
+	}
+}

--- a/client/components/timer/time-display/gan-timer/protocol.test.ts
+++ b/client/components/timer/time-display/gan-timer/protocol.test.ts
@@ -1,0 +1,121 @@
+import {
+	buildTimerEvent,
+	crc16ccit,
+	GanTimerState,
+	isValidEventData,
+	makeTimeFromRaw,
+	normalizeUuid,
+} from '@/components/timer/time-display/gan-timer/protocol';
+
+/**
+ * Build a well-formed GAN Smart Timer state packet.
+ *
+ * Layout: [0]=0xFE magic, [1]=length, [2]=?, [3]=state, [4..]=payload, last 2 bytes=CRC16.
+ * The CRC is computed over the packet starting at offset 2, excluding the trailing CRC.
+ */
+function buildPacket(state: number, payload: number[] = []): DataView {
+	const body = [0xfe, 0x00, 0x00, state, ...payload];
+	const crcInput = new Uint8Array(body.slice(2));
+	const crc = crc16ccit(crcInput.buffer);
+
+	const bytes = new Uint8Array([...body, crc & 0xff, (crc >> 8) & 0xff]);
+	return new DataView(bytes.buffer);
+}
+
+describe('gan timer protocol', () => {
+	describe('isValidEventData', () => {
+		it('accepts a packet with the right magic byte and CRC', () => {
+			expect(isValidEventData(buildPacket(GanTimerState.IDLE))).toBe(true);
+		});
+
+		it('rejects a packet with a bad magic byte', () => {
+			const packet = buildPacket(GanTimerState.IDLE);
+			packet.setUint8(0, 0x00);
+			expect(isValidEventData(packet)).toBe(false);
+		});
+
+		it('rejects a packet with a corrupted CRC', () => {
+			const packet = buildPacket(GanTimerState.IDLE);
+			packet.setUint8(packet.byteLength - 1, 0xff);
+			packet.setUint8(packet.byteLength - 2, 0xff);
+			expect(isValidEventData(packet)).toBe(false);
+		});
+
+		it('rejects empty and missing data instead of throwing', () => {
+			expect(isValidEventData(new DataView(new ArrayBuffer(0)))).toBe(false);
+			expect(isValidEventData(null)).toBe(false);
+			expect(isValidEventData(undefined)).toBe(false);
+		});
+
+		it('validates a packet backed by a buffer with a non-zero byte offset', () => {
+			// Some Web Bluetooth implementations hand back a DataView into a
+			// larger pooled buffer. CRC must be computed over the view, not the buffer.
+			const source = buildPacket(GanTimerState.RUNNING);
+			const padded = new Uint8Array(4 + source.byteLength);
+			padded.set(new Uint8Array(source.buffer), 4);
+
+			const offsetView = new DataView(padded.buffer, 4, source.byteLength);
+			expect(isValidEventData(offsetView)).toBe(true);
+		});
+	});
+
+	describe('buildTimerEvent', () => {
+		it.each([
+			['HANDS_ON', GanTimerState.HANDS_ON],
+			['HANDS_OFF', GanTimerState.HANDS_OFF],
+			['GET_SET', GanTimerState.GET_SET],
+			['RUNNING', GanTimerState.RUNNING],
+			['IDLE', GanTimerState.IDLE],
+			['FINISHED', GanTimerState.FINISHED],
+		])('decodes the %s state', (_name, state) => {
+			expect(buildTimerEvent(buildPacket(state))).toEqual({state});
+		});
+
+		it('decodes the recorded time on a STOPPED event', () => {
+			// 1 minute, 23 seconds, 456 milliseconds
+			const packet = buildPacket(GanTimerState.STOPPED, [1, 23, 456 & 0xff, 456 >> 8]);
+			const event = buildTimerEvent(packet);
+
+			expect(event?.state).toBe(GanTimerState.STOPPED);
+			expect(event?.recordedTime?.asTimestamp).toBe(83456);
+			expect(event?.recordedTime?.toString()).toBe('1:23.456');
+		});
+
+		it('drops packets carrying an unknown state rather than emitting garbage', () => {
+			expect(buildTimerEvent(buildPacket(42))).toBeNull();
+		});
+
+		it('drops a STOPPED packet that is too short to hold a time', () => {
+			expect(buildTimerEvent(buildPacket(GanTimerState.STOPPED))).toBeNull();
+		});
+	});
+
+	describe('makeTimeFromRaw', () => {
+		it('reads minutes, seconds and little-endian milliseconds', () => {
+			const bytes = new Uint8Array([2, 5, 7 & 0xff, 7 >> 8]);
+			const time = makeTimeFromRaw(new DataView(bytes.buffer), 0);
+
+			expect(time.minutes).toBe(2);
+			expect(time.seconds).toBe(5);
+			expect(time.milliseconds).toBe(7);
+			expect(time.asTimestamp).toBe(125007);
+			expect(time.toString()).toBe('2:05.007');
+		});
+	});
+
+	describe('normalizeUuid', () => {
+		it('expands a 16 bit UUID to its full 128 bit form', () => {
+			expect(normalizeUuid('fff0')).toBe('0000fff0-0000-1000-8000-00805f9b34fb');
+		});
+
+		it('lowercases a full UUID so comparisons are case insensitive', () => {
+			expect(normalizeUuid('0000FFF0-0000-1000-8000-00805F9B34FB')).toBe(
+				'0000fff0-0000-1000-8000-00805f9b34fb'
+			);
+		});
+
+		it('accepts a numeric 16 bit UUID as reported by some browsers', () => {
+			expect(normalizeUuid(0xfff0)).toBe('0000fff0-0000-1000-8000-00805f9b34fb');
+		});
+	});
+});

--- a/client/components/timer/time-display/gan-timer/protocol.ts
+++ b/client/components/timer/time-display/gan-timer/protocol.ts
@@ -1,0 +1,180 @@
+/**
+ * Wire protocol for the GAN Smart Timer.
+ *
+ * Kept free of any Web Bluetooth types so it can be unit tested directly.
+ * Credits to Andy Fedotov (https://github.com/afedotov/gan-web-bluetooth), whose
+ * reverse engineering of the protocol this is based on.
+ */
+
+/**
+ * GAN Smart Timer events/states.
+ *
+ * Values match the byte the timer puts at offset 3 of a state packet, and are
+ * kept identical to the `gan-web-bluetooth` enum this driver replaced.
+ */
+export enum GanTimerState {
+	/** Fired when timer is disconnected from bluetooth */
+	DISCONNECT = 0,
+	/** Grace delay is expired and timer is ready to start */
+	GET_SET = 1,
+	/** Hands removed from the timer before grace delay expired */
+	HANDS_OFF = 2,
+	/** Timer is running */
+	RUNNING = 3,
+	/** Timer is stopped, this event includes recorded time */
+	STOPPED = 4,
+	/** Timer is reset and idle */
+	IDLE = 5,
+	/** Hands are placed on the timer */
+	HANDS_ON = 6,
+	/** Timer moves to this state immediately after STOPPED */
+	FINISHED = 7,
+}
+
+const KNOWN_STATES = new Set<number>([
+	GanTimerState.DISCONNECT,
+	GanTimerState.GET_SET,
+	GanTimerState.HANDS_OFF,
+	GanTimerState.RUNNING,
+	GanTimerState.STOPPED,
+	GanTimerState.IDLE,
+	GanTimerState.HANDS_ON,
+	GanTimerState.FINISHED,
+]);
+
+/** Representation of a time value */
+export interface GanTimerTime {
+	readonly minutes: number;
+	readonly seconds: number;
+	readonly milliseconds: number;
+	readonly asTimestamp: number;
+	toString(): string;
+}
+
+/** Timer state event */
+export interface GanTimerEvent {
+	/** Current timer state */
+	state: GanTimerState;
+	/** Recorded time value, only present on a STOPPED event */
+	recordedTime?: GanTimerTime;
+}
+
+/** Representation of the time values recorded in the timer's memory */
+export interface GanTimerRecordedTimes {
+	displayTime: GanTimerTime;
+	previousTimes: [GanTimerTime, GanTimerTime, GanTimerTime];
+}
+
+export function makeTime(min: number, sec: number, msec: number): GanTimerTime {
+	return {
+		minutes: min,
+		seconds: sec,
+		milliseconds: msec,
+		asTimestamp: 60000 * min + 1000 * sec + msec,
+		toString: () =>
+			`${min.toString(10)}:${sec.toString(10).padStart(2, '0')}.${msec
+				.toString(10)
+				.padStart(3, '0')}`,
+	};
+}
+
+export function makeTimeFromRaw(data: DataView, offset: number): GanTimerTime {
+	return makeTime(data.getUint8(offset), data.getUint8(offset + 1), data.getUint16(offset + 2, true));
+}
+
+export function makeTimeFromTimestamp(timestamp: number): GanTimerTime {
+	return makeTime(
+		Math.trunc(timestamp / 60000),
+		Math.trunc((timestamp % 60000) / 1000),
+		Math.trunc(timestamp % 1000)
+	);
+}
+
+/** Calculate ArrayBuffer checksum using a CRC-16/CCITT-FALSE variation */
+export function crc16ccit(buff: ArrayBuffer): number {
+	const dataView = new DataView(buff);
+	let crc = 0xffff;
+	for (let i = 0; i < dataView.byteLength; ++i) {
+		crc ^= dataView.getUint8(i) << 8;
+		for (let j = 0; j < 8; ++j) {
+			crc = (crc & 0x8000) > 0 ? (crc << 1) ^ 0x1021 : crc << 1;
+		}
+	}
+	return crc & 0xffff;
+}
+
+/** Ensure a received timer packet has valid data: check the magic byte and CRC */
+export function isValidEventData(data: DataView | null | undefined): boolean {
+	try {
+		if (!data || data.byteLength < 6 || data.getUint8(0) !== 0xfe) {
+			return false;
+		}
+
+		const eventCRC = data.getUint16(data.byteLength - 2, true);
+		// Slice relative to the view, not the backing buffer, since some browsers
+		// hand back a DataView into a larger pooled ArrayBuffer.
+		const payload = new Uint8Array(data.buffer, data.byteOffset + 2, data.byteLength - 4);
+		const calculatedCRC = crc16ccit(payload.slice().buffer);
+
+		return eventCRC === calculatedCRC;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Build an event from a raw state packet.
+ *
+ * Returns null for anything we can't confidently decode, so a single odd packet
+ * gets dropped rather than tearing down the whole connection.
+ */
+export function buildTimerEvent(data: DataView): GanTimerEvent | null {
+	try {
+		const state = data.getUint8(3);
+		if (!KNOWN_STATES.has(state)) {
+			return null;
+		}
+
+		if (state === GanTimerState.STOPPED) {
+			// state byte + 4 time bytes + 2 CRC bytes must all fit
+			if (data.byteLength < 10) {
+				return null;
+			}
+			return {state, recordedTime: makeTimeFromRaw(data, 4)};
+		}
+
+		return {state};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Expand a UUID to its lowercase 128 bit form so that service and characteristic
+ * UUIDs can be compared regardless of how the browser reported them.
+ */
+export function normalizeUuid(uuid: string | number): string {
+	if (typeof uuid === 'number') {
+		return `0000${uuid.toString(16).padStart(4, '0')}-0000-1000-8000-00805f9b34fb`;
+	}
+
+	const trimmed = uuid.trim().toLowerCase();
+	if (/^(0x)?[0-9a-f]{1,4}$/.test(trimmed)) {
+		return `0000${trimmed.replace(/^0x/, '').padStart(4, '0')}-0000-1000-8000-00805f9b34fb`;
+	}
+
+	return trimmed;
+}
+
+/** Render a DataView as a hex string, for logging undecodable packets */
+export function hexdump(data: DataView | null | undefined): string {
+	if (!data) {
+		return '';
+	}
+
+	const bytes: string[] = [];
+	for (let i = 0; i < data.byteLength; i++) {
+		bytes.push(data.getUint8(i).toString(16).padStart(2, '0'));
+	}
+	return bytes.join(' ');
+}


### PR DESCRIPTION
Fixes #185

GAN Smart Cubes refused to connect despite appearing "paired" in the OS. The library opens its own device chooser and calls `requestDevice()` a second time, which Chrome rejects outside a user gesture. This error was never caught. Additionally, the library needs manufacturer-specific advertisement data to read the cube's MAC address, which Chrome strips unless company identifiers are declared at request time.

## Solution

- New `connectGanCubeDevice()` feeds the library an already-chosen device via a scoped `requestDevice` override
- Declares GAN manufacturer ID range in `optionalManufacturerData` so Chrome doesn't strip MAC data
- MAC address normalization and per-device persistence
- Proper error handling with user-friendly messages
- Fixed battery level and cube state tracking

## Testing

- 41 new unit tests covering connection logic, MAC normalization, error messages
- Verified key test fails without the fix, passes with it
- Full suite: 82 passed, 0 new failures
- TypeScript clean, no new lint issues